### PR TITLE
feat(agents): Add delete agent command and refactor other agent commands

### DIFF
--- a/pkg/apis/agent.go
+++ b/pkg/apis/agent.go
@@ -143,19 +143,19 @@ func ConnectAgent(agent types.Agent, cred types.Credentials) (AgentConnectionDat
 	}
 }
 
-type DeleteAgentData struct {
+type DisconnectAgentData struct {
 	Errors []struct {
 		Message string   `json:"message"`
 		Path    []string `json:"path"`
 	} `json:"errors"`
-	Data DeleteAgentDetails `json:"data"`
+	Data DisconnectAgentDetails `json:"data"`
 }
 
-type DeleteAgentDetails struct {
+type DisconnectAgentDetails struct {
 	Message string `json:"deleteClusters"`
 }
 
-type DeleteAgentGraphQLRequest struct {
+type DisconnectAgentGraphQLRequest struct {
 	Query     string `json:"query"`
 	Variables struct {
 		ProjectID  string    `json:"projectID"`
@@ -163,10 +163,10 @@ type DeleteAgentGraphQLRequest struct {
 	} `json:"variables"`
 }
 
-// DeleteAgent sends GraphQL API request for deleting ChaosAgent(s).
-func DeleteAgent(projectID string, clusterIDs []*string, cred types.Credentials) (DeleteAgentData, error) {
+// DisconnectAgent sends GraphQL API request for disconnecting ChaosAgent(s).
+func DisconnectAgent(projectID string, clusterIDs []*string, cred types.Credentials) (DisconnectAgentData, error) {
 
-	var gqlReq DeleteAgentGraphQLRequest
+	var gqlReq DisconnectAgentGraphQLRequest
 	var err error
 
 	gqlReq.Query = `mutation deleteClusters($projectID: String!, $clusterIDs: [String]!) {
@@ -180,7 +180,7 @@ func DeleteAgent(projectID string, clusterIDs []*string, cred types.Credentials)
 
 	query, err := json.Marshal(gqlReq)
 	if err != nil {
-		return DeleteAgentData{}, err
+		return DisconnectAgentData{}, err
 	}
 
 	resp, err := SendRequest(
@@ -192,28 +192,28 @@ func DeleteAgent(projectID string, clusterIDs []*string, cred types.Credentials)
 		string(types.Post),
 	)
 	if err != nil {
-		return DeleteAgentData{}, err
+		return DisconnectAgentData{}, err
 	}
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return DeleteAgentData{}, err
+		return DisconnectAgentData{}, err
 	}
 
 	if resp.StatusCode == http.StatusOK {
-		var deleteAgentData DeleteAgentData
-		err = json.Unmarshal(bodyBytes, &deleteAgentData)
+		var disconnectAgentData DisconnectAgentData
+		err = json.Unmarshal(bodyBytes, &disconnectAgentData)
 		if err != nil {
-			return DeleteAgentData{}, err
+			return DisconnectAgentData{}, err
 		}
 
-		if len(deleteAgentData.Errors) > 0 {
-			return DeleteAgentData{}, errors.New(deleteAgentData.Errors[0].Message)
+		if len(disconnectAgentData.Errors) > 0 {
+			return DisconnectAgentData{}, errors.New(disconnectAgentData.Errors[0].Message)
 		}
 
-		return deleteAgentData, nil
+		return disconnectAgentData, nil
 	} else {
-		return DeleteAgentData{}, err
+		return DisconnectAgentData{}, err
 	}
 }

--- a/pkg/apis/agent.go
+++ b/pkg/apis/agent.go
@@ -48,7 +48,7 @@ type AgentList struct {
 
 // GetAgentList lists the agent connected to the specified project
 func GetAgentList(c types.Credentials, pid string) (AgentData, error) {
-	query := `{"query":"query{\n  listClusters(projectID: \"` + pid + `\"){\n  clusterID clusterName isActive \n  }\n}"}`
+	query := `{"query":"query{\n  listClusters(projectID: \"` + pid + `\"){\n  clusterID clusterName isActive isRegistered\n  }\n}"}`
 	resp, err := SendRequest(SendRequestParams{Endpoint: c.Endpoint + utils.GQLAPIPath, Token: c.Token}, []byte(query), string(types.Post))
 	if err != nil {
 		return AgentData{}, err

--- a/pkg/cmd/connect/agent.go
+++ b/pkg/cmd/connect/agent.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package create
+package connect
 
 import (
 	"encoding/json"
@@ -32,14 +32,14 @@ import (
 // agentCmd represents the agent command
 var agentCmd = &cobra.Command{
 	Use: "agent",
-	Short: `Create an external agent.
+	Short: `Connect an external agent.
 	Example(s):
-	#create an agent
-	litmusctl create agent --agent-name="new-agent" --non-interactive
+	#connect an agent
+	litmusctl connect agent --agent-name="new-agent" --non-interactive
 
-	#create an agent within a project
-	litmusctl create agent --agent-name="new-agent" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
-	
+	#connect an agent within a project
+	litmusctl connect agent --agent-name="new-agent" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
+
 	Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 `,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -270,7 +270,7 @@ var agentCmd = &cobra.Command{
 }
 
 func init() {
-	CreateCmd.AddCommand(agentCmd)
+	ConnectCmd.AddCommand(agentCmd)
 
 	agentCmd.Flags().BoolP("non-interactive", "n", false, "Set it to true for non interactive mode | Note: Always set the boolean flag as --non-interactive=Boolean")
 	agentCmd.Flags().StringP("kubeconfig", "k", "", "Set to pass kubeconfig file if it is not in the default location ($HOME/.kube/config)")

--- a/pkg/cmd/connect/connect.go
+++ b/pkg/cmd/connect/connect.go
@@ -13,22 +13,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package create
+package connect
 
 import (
 	"github.com/spf13/cobra"
 )
 
-// createCmd represents the create command
-var CreateCmd = &cobra.Command{
-	Use: "create",
-	Short: `Create resources for LitmusChaos agent plane.
+// connectCmd represents the connect command
+var ConnectCmd = &cobra.Command{
+	Use: "connect",
+	Short: `Connect resources for LitmusChaos agent plane.
 		Examples:
-		#create a project
-		litmusctl create project --name new-proj
+		#connect an agent
+		litmusctl connect agent --agent-name="new-agent" --non-interactive
 
-		#create a chaos workflow from a file
-		litmusctl create workflow -f workflow.yaml --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --agent-id="d861b650-1549-4574-b2ba-ab754058dd04"
+		#connect an agent within a project
+		litmusctl connect agent --agent-name="new-agent" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/delete/agent.go
+++ b/pkg/cmd/delete/agent.go
@@ -1,0 +1,114 @@
+/*
+Copyright © 2021 The LitmusChaos Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package delete
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/litmuschaos/litmusctl/pkg/apis"
+	"github.com/litmuschaos/litmusctl/pkg/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// agentCmd represents the agent command
+var agentCmd = &cobra.Command{
+	Use: "agent",
+	Short: `Delete a ChaosAgent
+	Example:
+	#delete an agent
+		litmusctl delete agent c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
+
+	Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
+	`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// Fetch user credentials
+		credentials, err := utils.GetCredentials(cmd)
+		utils.PrintError(err)
+
+		projectID, err := cmd.Flags().GetString("project-id")
+		utils.PrintError(err)
+
+		// Handle blank input for project ID
+		if projectID == "" {
+			utils.White_B.Print("\nEnter the Project ID: ")
+			fmt.Scanln(&projectID)
+
+			if projectID == "" {
+				utils.Red.Println("⛔ Project ID can't be empty!!")
+				os.Exit(1)
+			}
+		}
+
+		agentID := args[0]
+
+		// Handle blank input for agent ID
+		if agentID == "" {
+			utils.White_B.Print("\nEnter the Agent ID: ")
+			fmt.Scanln(&agentID)
+
+			if agentID == "" {
+				utils.Red.Println("⛔ Agent ID can't be empty!!")
+				os.Exit(1)
+			}
+		}
+
+		// Perform authorization
+		userDetails, err := apis.GetProjectDetails(credentials)
+		utils.PrintError(err)
+		var editAccess = false
+		var project apis.Project
+		for _, p := range userDetails.Data.Projects {
+			if p.ID == projectID {
+				project = p
+			}
+		}
+		for _, member := range project.Members {
+			if (member.UserID == userDetails.Data.ID) && (member.Role == "Owner" || member.Role == "Editor") {
+				editAccess = true
+			}
+		}
+		if !editAccess {
+			utils.Red.Println("⛔ User doesn't have edit access to the project!!")
+			os.Exit(1)
+		}
+
+		// Make API call
+		var agentIDs []*string
+		agentIDs = append(agentIDs, &agentID)
+		deletedAgent, err := apis.DeleteAgent(projectID, agentIDs, credentials)
+		if err != nil {
+			utils.Red.Println("\n❌ Error in deleting ChaosAgent: ", err.Error())
+			os.Exit(1)
+		}
+
+		if strings.Contains(deletedAgent.Data.Message, "Successfully deleted clusters") {
+			utils.White_B.Println("\n🚀 ChaosAgent successfully deleted.")
+		} else {
+			utils.White_B.Println("\n❌ Failed to delete ChaosAgent. Please check if the ID is correct or not.")
+		}
+	},
+}
+
+func init() {
+	DeleteCmd.AddCommand(agentCmd)
+
+	agentCmd.Flags().String("project-id", "", "Set the project-id to create workflow for the particular project. To see the projects, apply litmusctl get projects")
+}

--- a/pkg/cmd/delete/delete.go
+++ b/pkg/cmd/delete/delete.go
@@ -1,0 +1,32 @@
+/*
+Copyright © 2021 The LitmusChaos Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package delete
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// deleteCmd represents the delete command
+var DeleteCmd = &cobra.Command{
+	Use: "delete",
+	Short: `Delete resources for LitmusChaos agent plane.
+		Examples:
+		#delete an agent
+		litmusctl delete agent c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
+
+		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
+	`,
+}

--- a/pkg/cmd/disconnect/agent.go
+++ b/pkg/cmd/disconnect/agent.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package delete
+package disconnect
 
 import (
 	"fmt"
@@ -29,10 +29,10 @@ import (
 // agentCmd represents the agent command
 var agentCmd = &cobra.Command{
 	Use: "agent",
-	Short: `Delete a ChaosAgent
+	Short: `Disconnect a ChaosAgent
 	Example:
-	#delete an agent
-		litmusctl delete agent c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
+	#disconnect an agent
+	litmusctl disconnect agent c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
 
 	Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,
@@ -93,22 +93,22 @@ var agentCmd = &cobra.Command{
 		// Make API call
 		var agentIDs []*string
 		agentIDs = append(agentIDs, &agentID)
-		deletedAgent, err := apis.DeleteAgent(projectID, agentIDs, credentials)
+		disconnectedAgent, err := apis.DisconnectAgent(projectID, agentIDs, credentials)
 		if err != nil {
-			utils.Red.Println("\n❌ Error in deleting ChaosAgent: ", err.Error())
+			utils.Red.Println("\n❌ Error in disconnecting ChaosAgent: ", err.Error())
 			os.Exit(1)
 		}
 
-		if strings.Contains(deletedAgent.Data.Message, "Successfully deleted clusters") {
-			utils.White_B.Println("\n🚀 ChaosAgent successfully deleted.")
+		if strings.Contains(disconnectedAgent.Data.Message, "Successfully deleted clusters") {
+			utils.White_B.Println("\n🚀 ChaosAgent successfully disconnected.")
 		} else {
-			utils.White_B.Println("\n❌ Failed to delete ChaosAgent. Please check if the ID is correct or not.")
+			utils.White_B.Println("\n❌ Failed to disconnect ChaosAgent. Please check if the ID is correct or not.")
 		}
 	},
 }
 
 func init() {
-	DeleteCmd.AddCommand(agentCmd)
+	DisconnectCmd.AddCommand(agentCmd)
 
 	agentCmd.Flags().String("project-id", "", "Set the project-id to create workflow for the particular project. To see the projects, apply litmusctl get projects")
 }

--- a/pkg/cmd/disconnect/disconnect.go
+++ b/pkg/cmd/disconnect/disconnect.go
@@ -13,19 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package delete
+package disconnect
 
 import (
 	"github.com/spf13/cobra"
 )
 
-// deleteCmd represents the delete command
-var DeleteCmd = &cobra.Command{
-	Use: "delete",
-	Short: `Delete resources for LitmusChaos agent plane.
+// disconnectCmd represents the disconnect command
+var DisconnectCmd = &cobra.Command{
+	Use: "disconnect",
+	Short: `Disconnect resources for LitmusChaos agent plane.
 		Examples:
-		#delete an agent
-		litmusctl delete agent c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
+		#disconnect an agent
+		litmusctl disconnect agent c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/get/agents.go
+++ b/pkg/cmd/get/agents.go
@@ -63,7 +63,7 @@ var agentsCmd = &cobra.Command{
 		case "":
 
 			writer := tabwriter.NewWriter(os.Stdout, 4, 8, 1, '\t', 0)
-			utils.White_B.Fprintln(writer, "AGENT ID\tAGENT NAME\tSTATUS\t")
+			utils.White_B.Fprintln(writer, "AGENTID\tAGENTNAME\tSTATUS\tREGISTRATION\t")
 
 			for _, agent := range agents.Data.GetAgent {
 				var status string
@@ -72,7 +72,14 @@ var agentsCmd = &cobra.Command{
 				} else {
 					status = "INACTIVE"
 				}
-				utils.White.Fprintln(writer, agent.ClusterID+"\t"+agent.AgentName+"\t"+status+"\t")
+
+				var isRegistered string
+				if agent.IsRegistered {
+					isRegistered = "REGISTERED"
+				} else {
+					isRegistered = "NOT REGISTERED"
+				}
+				utils.White.Fprintln(writer, agent.ClusterID+"\t"+agent.AgentName+"\t"+status+"\t"+isRegistered+"\t")
 			}
 			writer.Flush()
 		}

--- a/pkg/cmd/get/agents.go
+++ b/pkg/cmd/get/agents.go
@@ -63,7 +63,7 @@ var agentsCmd = &cobra.Command{
 		case "":
 
 			writer := tabwriter.NewWriter(os.Stdout, 4, 8, 1, '\t', 0)
-			utils.White_B.Fprintln(writer, "AGENTID\tAGENTNAME\tSTATUS\tREGISTRATION\t")
+			utils.White_B.Fprintln(writer, "AGENT ID \tAGENT NAME\tSTATUS\tREGISTRATION\t")
 
 			for _, agent := range agents.Data.GetAgent {
 				var status string

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -23,13 +23,13 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/litmuschaos/litmusctl/pkg/cmd/disconnect"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/upgrade"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/version"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
 
 	"github.com/litmuschaos/litmusctl/pkg/cmd/config"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/create"
-	"github.com/litmuschaos/litmusctl/pkg/cmd/delete"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/get"
 	config2 "github.com/litmuschaos/litmusctl/pkg/config"
 	"github.com/spf13/cobra"
@@ -59,7 +59,7 @@ func init() {
 	rootCmd.AddCommand(config.ConfigCmd)
 	rootCmd.AddCommand(create.CreateCmd)
 	rootCmd.AddCommand(get.GetCmd)
-	rootCmd.AddCommand(delete.DeleteCmd)
+	rootCmd.AddCommand(disconnect.DisconnectCmd)
 	rootCmd.AddCommand(version.VersionCmd)
 	rootCmd.AddCommand(upgrade.UpgradeCmd)
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/litmuschaos/litmusctl/pkg/cmd/connect"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/disconnect"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/upgrade"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/version"
@@ -59,6 +60,7 @@ func init() {
 	rootCmd.AddCommand(config.ConfigCmd)
 	rootCmd.AddCommand(create.CreateCmd)
 	rootCmd.AddCommand(get.GetCmd)
+	rootCmd.AddCommand(connect.ConnectCmd)
 	rootCmd.AddCommand(disconnect.DisconnectCmd)
 	rootCmd.AddCommand(version.VersionCmd)
 	rootCmd.AddCommand(upgrade.UpgradeCmd)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/litmuschaos/litmusctl/pkg/cmd/config"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/create"
-	"github.com/litmuschaos/litmusctl/pkg/cmd/get"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/delete"
+	"github.com/litmuschaos/litmusctl/pkg/cmd/get"
 	config2 "github.com/litmuschaos/litmusctl/pkg/config"
 	"github.com/spf13/cobra"
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/litmuschaos/litmusctl/pkg/cmd/config"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/create"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/get"
+	"github.com/litmuschaos/litmusctl/pkg/cmd/delete"
 	config2 "github.com/litmuschaos/litmusctl/pkg/config"
 	"github.com/spf13/cobra"
 
@@ -58,6 +59,7 @@ func init() {
 	rootCmd.AddCommand(config.ConfigCmd)
 	rootCmd.AddCommand(create.CreateCmd)
 	rootCmd.AddCommand(get.GetCmd)
+	rootCmd.AddCommand(delete.DeleteCmd)
 	rootCmd.AddCommand(version.VersionCmd)
 	rootCmd.AddCommand(upgrade.UpgradeCmd)
 


### PR DESCRIPTION
This PR adds the following changes,
- a command to delete (read delete and disconnect) a ChaosAgent present in the project.
- adds the field `isRegistered` in the output of `get agents` command.
- refactors the `create agent` command to `connect agent` for consistency.

Signed-off-by: PrayagS <prayagsavsani@gmail.com>