### PR TITLE
docs(agents|workflows): Update usage documentation

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -18,7 +18,7 @@ Litmusctl is using the `.litmusconfig` config file to manage multiple accounts
 2. Otherwise, the ${HOME}/.litmusconfig file is used, and no merging takes place.
 
 Litmusctl supports both interactive and non-interactive(flag based) modes.
-> Only `litmusctl create agent`  command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then litmusctl takes input in an interactive mode.
+> Only `litmusctl connect agent`  command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then litmusctl takes input in an interactive mode.
 
 ### Installation modes
 Litmusctl can install an agent in two different modes.
@@ -38,7 +38,7 @@ litmusctl config set-account --endpoint="" --username="" --password=""
 * To create an agent without a project
 >Note: If the user doesn't have any project, it will create a random project and add the agent in that random project.
 ```shell
-litmusctl create agent --agent-name="" --non-interactive
+litmusctl connect agent --agent-name="" --non-interactive
 ```
 
 ### Or,
@@ -47,10 +47,10 @@ litmusctl create agent --agent-name="" --non-interactive
 > Note: To get `project-id`. Apply `litmusctl get projects`
 
 ```shell
-litmusctl create agent --agent-name="" --project-id="" --non-interactive
+litmusctl connect agent --agent-name="" --project-id="" --non-interactive
 ```
 
-### Flags for `create agent` command
+### Flags for `connect agent` command
 <table>
 <tr>
     <th>Flag</th>
@@ -201,8 +201,8 @@ litmusctl get projects
 
 ```
 PROJECT ID                                PROJECT NAME       CREATEDAT
-50addd40-8767-448c-a91a-5071543a2d8e      Developer Project  2021-07-21 14:38:51 +0530 IST     
-7a4a259a-1ae5-4204-ae83-89a8838eaec3      DevOps Project     2021-07-21 14:39:14 +0530 IST     
+50addd40-8767-448c-a91a-5071543a2d8e      Developer Project  2021-07-21 14:38:51 +0530 IST
+7a4a259a-1ae5-4204-ae83-89a8838eaec3      DevOps Project     2021-07-21 14:39:14 +0530 IST
 ```
 
 
@@ -214,8 +214,8 @@ litmusctl get agents --project-id=""
 **Output:**
 
 ```
-AGENTID                                AGENTNAME          STATUS 
-55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE 
+AGENTID                                AGENTNAME          STATUS
+55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE
 13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE
 ```
 

--- a/Usage.md
+++ b/Usage.md
@@ -240,7 +240,7 @@ AGENTID                                AGENTNAME          STATUS     REGISTRATIO
 
 * To disconnect an agent, issue the following command..
 ```shell
-litmusctl disconnect agent f9799723-29f1-454c-b830-ae8ba7ee4c30 --project-id=""
+litmusctl disconnect agent <agent-id> --project-id=""
 ```
 
 **Output:**
@@ -282,7 +282,7 @@ Showing 1 of 1 workflow runs
 
 * To describe a particular chaos workflow, issue the following command.
 ```shell
-litmusctl describe workflow 9433b48c-4ab7-4544-8dab-4a7237619e09 --project-id=""
+litmusctl describe workflow <workflow-id> --project-id=""
 ```
 
 **Output:**
@@ -306,7 +306,7 @@ spec:
 
 * To delete a particular chaos workflow, issue the following command.
 ```shell
-litmusctl delete workflow df91c6b2-ad33-45ae-9a2f-00cb87978657 --project-id=""
+litmusctl delete workflow <workflow-id> --project-id=""
 ```
 
 **Output:**

--- a/Usage.md
+++ b/Usage.md
@@ -143,6 +143,24 @@ litmusctl connect agent --agent-name="" --project-id="" --non-interactive
     </tr>
 </table>
 
+---
+
+### Steps to create a Chaos Workflow
+
+* To setup an account with litmusctl
+```shell
+litmusctl config set-account --endpoint="" --username="" --password=""
+```
+
+* To create a Chaos Workflow by passing a manifest file
+> Note:
+> * To get `project-id`, apply `litmusctl get projects`
+> * To get `agent-id`, apply `litmusctl get agents --project-id=""`
+```shell
+litmusctl create workflow -f custom-chaos-workflow.yml --project-id="" --agent-id=""
+```
+
+---
 
 ### Additional commands
 
@@ -217,6 +235,72 @@ litmusctl get agents --project-id=""
 AGENTID                                AGENTNAME          STATUS
 55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE
 13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE
+```
+
+
+* To list the created workflows within a project, issue the following command.
+```shell
+litmusctl get workflows --project-id=""
+```
+
+**Output:**
+
+```
+WORKFLOW ID                          WORKFLOW NAME                    WORKFLOW TYPE     NEXT SCHEDULE AGENT ID                             AGENT NAME LAST UPDATED BY
+9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-workflow-1627980541 Non Cron Workflow None          f9799723-29f1-454c-b830-ae8ba7ee4c30 Self-Agent admin
+
+Showing 1 of 1 workflows
+```
+
+
+* To list all the chaos workflow runs within a project, issue the following command.
+```shell
+litmusctl get workflowruns --project-id=""
+```
+
+**Output:**
+
+```
+WORKFLOW RUN ID                      STATUS  RESILIENCY SCORE WORKFLOW ID                          WORKFLOW NAME                    TARGET AGENT LAST RUN                 EXECUTED BY
+8ceb712c-1ed4-40e6-adc4-01f78d281506 Running 0.00             9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-workflow-1627980541 Self-Agent   June 1 2022, 10:28:02 pm admin
+
+Showing 1 of 1 workflow runs
+```
+
+
+* To describe a particular chaos workflow, issue the following command.
+```shell
+litmusctl describe workflow 9433b48c-4ab7-4544-8dab-4a7237619e09 --project-id=""
+```
+
+**Output:**
+
+```
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+    creationTimestamp: null
+    labels:
+        cluster_id: f9799723-29f1-454c-b830-ae8ba7ee4c30
+        subject: custom-chaos-workflow_litmus
+        workflow_id: 9433b48c-4ab7-4544-8dab-4a7237619e09
+        workflows.argoproj.io/controller-instanceid: f9799723-29f1-454c-b830-ae8ba7ee4c30
+    name: custom-chaos-workflow-1627980541
+    namespace: litmus
+spec:
+...
+```
+
+
+* To delete a particular chaos workflow, issue the following command.
+```shell
+litmusctl delete workflow df91c6b2-ad33-45ae-9a2f-00cb87978657 --project-id=""
+```
+
+**Output:**
+
+```
+🚀 ChaosWorkflow successfully deleted.
 ```
 
 

--- a/Usage.md
+++ b/Usage.md
@@ -238,6 +238,18 @@ AGENTID                                AGENTNAME          STATUS
 ```
 
 
+* To disconnect an agent, issue the following command..
+```shell
+litmusctl disconnect agent f9799723-29f1-454c-b830-ae8ba7ee4c30 --project-id=""
+```
+
+**Output:**
+
+```
+🚀 ChaosAgent successfully disconnected.
+```
+
+
 * To list the created workflows within a project, issue the following command.
 ```shell
 litmusctl get workflows --project-id=""

--- a/Usage.md
+++ b/Usage.md
@@ -232,9 +232,9 @@ litmusctl get agents --project-id=""
 **Output:**
 
 ```
-AGENTID                                AGENTNAME          STATUS
-55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE
-13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE
+AGENTID                                AGENTNAME          STATUS     REGISTRATION
+55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE     REGISTERED
+13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE   NOT REGISTERED
 ```
 
 

--- a/Usage_interactive.md
+++ b/Usage_interactive.md
@@ -24,7 +24,7 @@ Litmusctl is using the `.litmusconfig` config file to manage multiple accounts
 
 Litmusctl supports both interactive and non-interactive(flag based) modes.
 
-> Only `litmusctl create agent` command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then litmusctl takes input in an interactive mode.
+> Only `litmusctl connect agent` command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then litmusctl takes input in an interactive mode.
 
 ### Steps to create an agent
 
@@ -54,7 +54,7 @@ account.username/admin configured
 - To create an agent in a cluster mode
 
 ```shell
-litmusctl create agent
+litmusctl connect agent
 ```
 
 There will be a list of existing projects displayed on the terminal. Select the desired project by entering the sequence number indicated against it.

--- a/Usage_interactive.md
+++ b/Usage_interactive.md
@@ -285,9 +285,9 @@ Enter the Project ID: 50addd40-8767-448c-a91a-5071543a2d8e
 **Output:**
 
 ```
-AGENTID                                AGENTNAME          STATUS
-55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE
-13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE
+AGENTID                                AGENTNAME          STATUS     REGISTRATION
+55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE     REGISTERED
+13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE   NOT REGISTERED
 ```
 
 

--- a/Usage_interactive.md
+++ b/Usage_interactive.md
@@ -291,6 +291,18 @@ AGENTID                                AGENTNAME          STATUS
 ```
 
 
+* To disconnect an agent, issue the following command..
+```shell
+litmusctl disconnect agent f9799723-29f1-454c-b830-ae8ba7ee4c30 --project-id=""
+```
+
+**Output:**
+
+```
+🚀 ChaosAgent successfully disconnected.
+```
+
+
 * To list the created workflows within a project, issue the following command.
 ```shell
 litmusctl get workflows --project-id=""

--- a/Usage_interactive.md
+++ b/Usage_interactive.md
@@ -185,6 +185,23 @@ To verify, if the connection process was successful you can view the list of con
 
 ---
 
+### Steps to create a Chaos Workflow
+
+* To setup an account with litmusctl
+```shell
+litmusctl config set-account --endpoint="" --username="" --password=""
+```
+
+* To create a Chaos Workflow by passing a manifest file
+> Note:
+> * To get `project-id`, apply `litmusctl get projects`
+> * To get `agent-id`, apply `litmusctl get agents --project-id=""`
+```shell
+litmusctl create workflow -f custom-chaos-workflow.yml --project-id="" --agent-id=""
+```
+
+---
+
 ### Additional commands
 
 - To view the current configuration of `.litmusconfig`, type:
@@ -272,6 +289,74 @@ AGENTID                                AGENTNAME          STATUS
 55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE
 13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE
 ```
+
+
+* To list the created workflows within a project, issue the following command.
+```shell
+litmusctl get workflows --project-id=""
+```
+
+**Output:**
+
+```
+WORKFLOW ID                          WORKFLOW NAME                    WORKFLOW TYPE     NEXT SCHEDULE AGENT ID                             AGENT NAME LAST UPDATED BY
+9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-workflow-1627980541 Non Cron Workflow None          f9799723-29f1-454c-b830-ae8ba7ee4c30 Self-Agent admin
+
+Showing 1 of 1 workflows
+```
+
+
+* To list all the chaos workflow runs within a project, issue the following command.
+```shell
+litmusctl get workflowruns --project-id=""
+```
+
+**Output:**
+
+```
+WORKFLOW RUN ID                      STATUS  RESILIENCY SCORE WORKFLOW ID                          WORKFLOW NAME                    TARGET AGENT LAST RUN                 EXECUTED BY
+8ceb712c-1ed4-40e6-adc4-01f78d281506 Running 0.00             9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-workflow-1627980541 Self-Agent   June 1 2022, 10:28:02 pm admin
+
+Showing 1 of 1 workflow runs
+```
+
+
+* To describe a particular chaos workflow, issue the following command.
+```shell
+litmusctl describe workflow 9433b48c-4ab7-4544-8dab-4a7237619e09 --project-id=""
+```
+
+**Output:**
+
+```
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+    creationTimestamp: null
+    labels:
+        cluster_id: f9799723-29f1-454c-b830-ae8ba7ee4c30
+        subject: custom-chaos-workflow_litmus
+        workflow_id: 9433b48c-4ab7-4544-8dab-4a7237619e09
+        workflows.argoproj.io/controller-instanceid: f9799723-29f1-454c-b830-ae8ba7ee4c30
+    name: custom-chaos-workflow-1627980541
+    namespace: litmus
+spec:
+...
+```
+
+
+* To delete a particular chaos workflow, issue the following command.
+```shell
+litmusctl delete workflow df91c6b2-ad33-45ae-9a2f-00cb87978657 --project-id=""
+```
+
+**Output:**
+
+```
+🚀 ChaosWorkflow successfully deleted.
+```
+
+---
 
 ## Flag details
 

--- a/Usage_interactive.md
+++ b/Usage_interactive.md
@@ -293,7 +293,7 @@ AGENTID                                AGENTNAME          STATUS     REGISTRATIO
 
 * To disconnect an agent, issue the following command..
 ```shell
-litmusctl disconnect agent f9799723-29f1-454c-b830-ae8ba7ee4c30 --project-id=""
+litmusctl disconnect agent <agent-id> --project-id=""
 ```
 
 **Output:**
@@ -335,7 +335,7 @@ Showing 1 of 1 workflow runs
 
 * To describe a particular chaos workflow, issue the following command.
 ```shell
-litmusctl describe workflow 9433b48c-4ab7-4544-8dab-4a7237619e09 --project-id=""
+litmusctl describe workflow <workflow-id> --project-id=""
 ```
 
 **Output:**
@@ -359,7 +359,7 @@ spec:
 
 * To delete a particular chaos workflow, issue the following command.
 ```shell
-litmusctl delete workflow df91c6b2-ad33-45ae-9a2f-00cb87978657 --project-id=""
+litmusctl delete workflow <workflow-id> --project-id=""
 ```
 
 **Output:**


### PR DESCRIPTION
This PR adds the following changes in the usage documentation for litmusctl.
- Refactor `create agent` to `connect agent`.
- Add `REGISTRATION` field in `get agents`.
- Add `disconnect agents` command under additional commands.
- Add instructions for `create workflow` command.
- Add other workflow commands viz. `get`, `delete`, and `describe` under additional commands.

Signed-off-by: PrayagS <prayagsavsani@gmail.com>