### PR TITLE
Update commands and logs with new terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,40 @@ The litmusctl CLI requires the following things:
 - kubectl- litmusctl is using kubectl under the hood to apply the manifest. To install kubectl, follow:  [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 
 
+## Compatibility matrix
+
+To check compatibility of chaosctl with Chaos Center
+
+<table>
+  <th>litmusctl version</th>
+  <th>Chaos Center supported versions</th>
+
+  <tr>
+    <td>0.6.0</td>
+    <td>2.2.0, 2.3.0</td>
+  </tr>
+  <tr>
+    <td>0.7.0</td>
+    <td>2.4.0, 2.5.0, 2.6.0, 2.7.0, 2.8.0</td>
+  </tr>
+  <tr>
+    <td>0.8.0</td>
+    <td>2.4.0, 2.5.0, 2.6.0, 2.7.0, 2.8.0</td>
+  </tr>
+  <tr>
+    <td>0.9.0</td>
+    <td>2.4.0, 2.5.0, 2.6.0, 2.7.0, 2.8.0</td>
+  </tr>
+  <tr>
+    <td>0.10.0</td>
+    <td>2.9.0, 2.10.0, 2.11.0</td>
+  </tr>
+  <tr>
+    <td>0.11.0</td>
+    <td>2.9.0, 2.10.0, 2.11.0</td>
+  </tr>
+</table>
+
 ## Installation
 
 To install the latest version of litmusctl follow the below steps:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/litmuschaos/litmusctl?style=social)](https://github.com/litmuschaos/litmusctl/stargazers)
 [![GitHub Release](https://img.shields.io/github/release/litmuschaos/litmusctl.svg?style=flat)]()
 
-The Litmuschaos command-line tool, litmusctl, allows you to manage litmuschaos's agent plane. You can use litmusctl to create agents, project, and manage multiple litmuschaos accounts. 
+The Litmuschaos command-line tool, litmusctl, allows you to manage litmuschaos's agent plane. You can use litmusctl to connect Chaos Delegates, create project, schedule Chaos Scenarios, disconnect Chaos Delegates and manage multiple litmuschaos accounts. 
 
 ## Usage
 For more information including a complete list of litmusctl operations, see the litmusctl reference documentation.
@@ -17,7 +17,7 @@ For more information including a complete list of litmusctl operations, see the 
 
 The litmusctl CLI requires the following things:
 
-- kubeconfig - litmusctl needs the kubeconfig of the k8s cluster where we need to connect litmus agents. The CLI currently uses the default path of kubeconfig i.e. `~/.kube/config`.
+- kubeconfig - litmusctl needs the kubeconfig of the k8s cluster where we need to connect litmus Chaos Delegates. The CLI currently uses the default path of kubeconfig i.e. `~/.kube/config`.
 - kubectl- litmusctl is using kubectl under the hood to apply the manifest. To install kubectl, follow:  [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 
 

--- a/Usage.md
+++ b/Usage.md
@@ -16,7 +16,7 @@ Litmusctl supports both interactive and non-interactive(flag based) modes.
 > Only `litmusctl connect chaos-delegate`  command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then litmusctl takes input in an interactive mode.
 
 ### Installation modes
-Litmusctl can install an Chaos Delegate in two different modes.
+Litmusctl can install a Chaos Delegate in two different modes.
 * cluster mode: With this mode, the Chaos Delegate can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=cluster`
 
 * namespace mode: With this mode, the Chaos Delegate can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=namespace`
@@ -34,7 +34,7 @@ litmusctl config set-account --endpoint="" --username="" --password=""
 > Note: To get `project-id`. Apply `litmusctl get projects`
 
 ```shell
-litmusctl connect chaos-delegate --chaos-delegate-name="" --project-id="" --non-interactive
+litmusctl connect chaos-delegate --name="" --project-id="" --non-interactive
 ```
 
 ### Flags for `connect chaos-delegate` command
@@ -225,7 +225,7 @@ CHAOS DELEGATE ID                            CHAOS DELEGATE NAME          STATUS
 ```
 
 
-* To disconnect an Chaos Delegate, issue the following command..
+* To disconnect a Chaos Delegate, issue the following command..
 ```shell
 litmusctl disconnect chaos-delegate <chaos-delegate-id> --project-id=""
 ```
@@ -237,7 +237,7 @@ litmusctl disconnect chaos-delegate <chaos-delegate-id> --project-id=""
 ```
 
 
-* To list the created scenarios within a project, issue the following command.
+* To list the created Chaos Scenarios within a project, issue the following command.
 ```shell
 litmusctl get chaos-scenarios --project-id=""
 ```
@@ -291,15 +291,15 @@ spec:
 ```
 
 
-* To delete a particular chaos sceanrio, issue the following command.
+* To delete a particular Chaos Scenario, issue the following command.
 ```shell
-litmusctl delete delete chaos-scenario <chaos-scenario-id> --project-id=""
+litmusctl delete chaos-scenario <chaos-scenario-id> --project-id=""
 ```
 
 **Output:**
 
 ```
-🚀 ChaosScenario successfully deleted.
+🚀 Chaos Scenario successfully deleted.
 ```
 
 

--- a/Usage.md
+++ b/Usage.md
@@ -1,16 +1,11 @@
-# Usage: Litmusctl v0.3.0 (Non-Interactive mode)
-> Notes:
-> * For litmusctl v0.3.0 or latest
-> * Compatible with Litmus 2.0.0-Beta9 or latest
-
 ### litmusctl Syntax
 `litmusctl` has a syntax to use as follows:
 
 ```shell
 litmusctl [command] [TYPE] [flags]
 ```
-* Command: refers to what you do want to perform (create, get and config)
-* Type: refers to the feature type you are performing a command against (agent, project etc.)
+* Command: refers to what you do want to perform (connect, create, get and config)
+* Type: refers to the feature type you are performing a command against (chaos-delegate, project etc.)
 * Flags: It takes some additional information for resource operations. For example, `--installation-mode` allows you to specify an installation mode.
 
 Litmusctl is using the `.litmusconfig` config file to manage multiple accounts
@@ -18,39 +13,31 @@ Litmusctl is using the `.litmusconfig` config file to manage multiple accounts
 2. Otherwise, the ${HOME}/.litmusconfig file is used, and no merging takes place.
 
 Litmusctl supports both interactive and non-interactive(flag based) modes.
-> Only `litmusctl connect agent`  command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then litmusctl takes input in an interactive mode.
+> Only `litmusctl connect chaos-delegate`  command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then litmusctl takes input in an interactive mode.
 
 ### Installation modes
-Litmusctl can install an agent in two different modes.
-* cluster mode: With this mode, the agent can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=cluster`
+Litmusctl can install an Chaos Delegate in two different modes.
+* cluster mode: With this mode, the Chaos Delegate can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=cluster`
 
-* namespace mode: With this mode, the agent can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=namespace`
+* namespace mode: With this mode, the Chaos Delegate can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=namespace`
 
-Note: With namespace mode, the user needs to create the namespace to install the agent as a prerequisite.
+Note: With namespace mode, the user needs to create the namespace to install the Chaos Delegate as a prerequisite.
 
-### Minimal steps to create an agent
+### Minimal steps to connect a Chaos Delegate
 
 * To setup an account with litmusctl
 ```shell
 litmusctl config set-account --endpoint="" --username="" --password=""
 ```
 
-* To create an agent without a project
->Note: If the user doesn't have any project, it will create a random project and add the agent in that random project.
-```shell
-litmusctl connect agent --agent-name="" --non-interactive
-```
-
-### Or,
-
-* To create an agent with an existing project
+* To create an Chaos Delegate with an existing project
 > Note: To get `project-id`. Apply `litmusctl get projects`
 
 ```shell
-litmusctl connect agent --agent-name="" --project-id="" --non-interactive
+litmusctl connect chaos-delegate --chaos-delegate-name="" --project-id="" --non-interactive
 ```
 
-### Flags for `connect agent` command
+### Flags for `connect chaos-delegate` command
 <table>
 <tr>
     <th>Flag</th>
@@ -58,34 +45,34 @@ litmusctl connect agent --agent-name="" --project-id="" --non-interactive
     <th>Type</th>
     <th>Description</th>
     <tr>
-        <td>--agent-description</td>
+        <td>--description</td>
         <td></td>
         <td>String</td>
-        <td>Set the agent description (default "---")</td>
+        <td>Set the Chaos Delegate description (default "---")</td>
     </tr>
     <tr>
-        <td>--agent-name</td>
+        <td>--name</td>
         <td></td>
         <td>String</td>
-        <td>Set the cluster-type to external for external agents | Supported=external/internal (default "external")</td>
+        <td>Set the name of Chaos Delegate which should be unique</td>
     </tr>
     <tr>
-        <td>--skip-agent-ssl</td>
+        <td>--skip-ssl</td>
         <td></td>
         <td>Boolean</td>
-        <td>Set whether agent will skip ssl/tls check (can be used for self-signed certs, if cert is not provided in portal) (default false)</td>
+        <td>Set whether Chaos Delegate will skip ssl/tls check (can be used for self-signed certs, if cert is not provided in portal) (default false)</td>
     </tr>
     <tr>
-        <td>--cluster-type</td>
+        <td>--chaos-delegate-type</td>
         <td></td>
         <td>String</td>
-        <td>Set the cluster-type to external for external agents | Supported=external/internal (default "external")</td>
+        <td>Set the chaos-delegate-type to external for external Chaos Delegates | Supported=external/internal (default "external")</td>
     </tr>
     <tr>
         <td>--installation-mode</td>
         <td></td>
         <td>String</td>
-        <td>Set the installation mode for the kind of agent | Supported=cluster/namespace (default "cluster")</td>
+        <td>Set the installation mode for the kind of Chaos Delegate | Supported=cluster/namespace (default "cluster")</td>
     </tr>
     <tr>
         <td>--kubeconfig</td>
@@ -97,13 +84,13 @@ litmusctl connect agent --agent-name="" --project-id="" --non-interactive
         <td>--namespace</td>
         <td></td>
         <td>String</td>
-        <td>Set the namespace for the agent installation (default "litmus")</td>
+        <td>Set the namespace for the Chaos Delegate installation (default "litmus")</td>
     </tr>
     <tr>
         <td>--node-selector</td>
         <td></td>
         <td>String</td>
-        <td>Set the node-selector for agent components | Format: key1=value1,key2=value2)
+        <td>Set the node-selector for Chaos Delegate components | Format: key1=value1,key2=value2)
     </tr>
     <tr>
         <td>--non-interactive</td>
@@ -133,7 +120,7 @@ litmusctl connect agent --agent-name="" --project-id="" --non-interactive
         <td>--service-account</td>
         <td></td>
         <td>String</td>
-        <td>Set the service account to be used by the agent (default "litmus")</td>
+        <td>Set the service account to be used by the Chaos Delegate (default "litmus")</td>
     </tr>
     <tr>
         <td>--config</td>
@@ -145,19 +132,19 @@ litmusctl connect agent --agent-name="" --project-id="" --non-interactive
 
 ---
 
-### Steps to create a Chaos Workflow
+### Steps to create a chaos scenaro
 
 * To setup an account with litmusctl
 ```shell
 litmusctl config set-account --endpoint="" --username="" --password=""
 ```
 
-* To create a Chaos Workflow by passing a manifest file
+* To create a Chaos Scenario by passing a manifest file
 > Note:
 > * To get `project-id`, apply `litmusctl get projects`
-> * To get `agent-id`, apply `litmusctl get agents --project-id=""`
+> * To get `chaos-delegate-id`, apply `litmusctl get chaos-delegates --project-id=""`
 ```shell
-litmusctl create workflow -f custom-chaos-workflow.yml --project-id="" --agent-id=""
+litmusctl create chaos-scenario -f custom-chaos-scenario.yml --project-id="" --chaos-delegate-id=""
 ```
 
 ---
@@ -224,65 +211,65 @@ PROJECT ID                                PROJECT NAME       CREATEDAT
 ```
 
 
-* To get an overview of the agents available within a project, issue the following command.
+* To get an overview of the Chaos Delegates available within a project, issue the following command.
 ```shell
-litmusctl get agents --project-id=""
+litmusctl get chaos-delegates --project-id=""
 ```
 
 **Output:**
 
 ```
-AGENTID                                AGENTNAME          STATUS     REGISTRATION
-55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE     REGISTERED
-13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE   NOT REGISTERED
+CHAOS DELEGATE ID                            CHAOS DELEGATE NAME          STATUS     REGISTRATION
+55ecc7f2-2754-43aa-8e12-6903e4c6183a   chaos-delegate-1            ACTIVE     REGISTERED
+13dsf3d1-5324-54af-4g23-5331g5v2364f   chaos-delegate-2            INACTIVE   NOT REGISTERED
 ```
 
 
-* To disconnect an agent, issue the following command..
+* To disconnect an Chaos Delegate, issue the following command..
 ```shell
-litmusctl disconnect agent <agent-id> --project-id=""
+litmusctl disconnect chaos-delegate <chaos-delegate-id> --project-id=""
 ```
 
 **Output:**
 
 ```
-🚀 ChaosAgent successfully disconnected.
+🚀 Chaos Delegate successfully disconnected.
 ```
 
 
-* To list the created workflows within a project, issue the following command.
+* To list the created scenarios within a project, issue the following command.
 ```shell
-litmusctl get workflows --project-id=""
+litmusctl get chaos-scenarios --project-id=""
 ```
 
 **Output:**
 
 ```
-WORKFLOW ID                          WORKFLOW NAME                    WORKFLOW TYPE     NEXT SCHEDULE AGENT ID                             AGENT NAME LAST UPDATED BY
-9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-workflow-1627980541 Non Cron Workflow None          f9799723-29f1-454c-b830-ae8ba7ee4c30 Self-Agent admin
+CHAOS SCENARIO ID                         CHAOS SCENARIO NAME                   CHAOS SCENARIO TYPE     NEXT SCHEDULE CHAOS DELEGATE ID                             CHAOS DELEGATE NAME LAST UPDATED BY
+9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-scenario-1627980541 Non Cron Chaos Scenario None          f9799723-29f1-454c-b830-ae8ba7ee4c30 Self-Chaos-delegate admin
 
-Showing 1 of 1 workflows
+Showing 1 of 1 Chaos Scenarios
 ```
 
 
-* To list all the chaos workflow runs within a project, issue the following command.
+* To list all the Chaos Scenario runs within a project, issue the following command.
 ```shell
-litmusctl get workflowruns --project-id=""
+litmusctl get chaos-scenario-runs  --project-id=""
 ```
 
 **Output:**
 
 ```
-WORKFLOW RUN ID                      STATUS  RESILIENCY SCORE WORKFLOW ID                          WORKFLOW NAME                    TARGET AGENT LAST RUN                 EXECUTED BY
-8ceb712c-1ed4-40e6-adc4-01f78d281506 Running 0.00             9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-workflow-1627980541 Self-Agent   June 1 2022, 10:28:02 pm admin
+CHAOS SCENARIO RUN ID                      STATUS  RESILIENCY SCORE CHAOS SCENARIO ID                          CHAOS SCENARIO NAME                    TARGET CHAOS DELEGATE LAST RUN                 EXECUTED BY
+8ceb712c-1ed4-40e6-adc4-01f78d281506 Running 0.00             9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-scenario-1627980541 Self-Chaos-Delegate   June 1 2022, 10:28:02 pm admin
 
-Showing 1 of 1 workflow runs
+Showing 1 of 1 Chaos Scenario runs
 ```
 
 
-* To describe a particular chaos workflow, issue the following command.
+* To describe a particular Chaos Scenario, issue the following command.
 ```shell
-litmusctl describe workflow <workflow-id> --project-id=""
+litmusctl describe chaos-scenario <chaos-scenario-id> --project-id=""
 ```
 
 **Output:**
@@ -294,26 +281,27 @@ metadata:
     creationTimestamp: null
     labels:
         cluster_id: f9799723-29f1-454c-b830-ae8ba7ee4c30
-        subject: custom-chaos-workflow_litmus
+        subject: custom-chaos-scenario_litmus
         workflow_id: 9433b48c-4ab7-4544-8dab-4a7237619e09
         workflows.argoproj.io/controller-instanceid: f9799723-29f1-454c-b830-ae8ba7ee4c30
-    name: custom-chaos-workflow-1627980541
+    name: custom-chaos-scenario-1627980541
     namespace: litmus
 spec:
 ...
 ```
 
 
-* To delete a particular chaos workflow, issue the following command.
+* To delete a particular chaos sceanrio, issue the following command.
 ```shell
-litmusctl delete workflow <workflow-id> --project-id=""
+litmusctl delete delete chaos-scenario <chaos-scenario-id> --project-id=""
 ```
 
 **Output:**
 
 ```
-🚀 ChaosWorkflow successfully deleted.
+🚀 ChaosScenario successfully deleted.
 ```
+
 
 
 For more information related to flags, Use `litmusctl --help`.

--- a/Usage_interactive.md
+++ b/Usage_interactive.md
@@ -13,8 +13,8 @@
 litmusctl [command] [TYPE] [flags]
 ```
 
-- Command: refers to what you do want to perform (create, get and config)
-- Type: refers to the feature type you are performing a command against (agent, project etc.)
+- Command: refers to what you do want to perform (connect, create, get and config)
+- Type: refers to the feature type you are performing a command against (chaos-delegate, project etc.)
 - Flags: It takes some additional information for resource operations. For example, `--installation-mode` allows you to specify an installation mode.
 
 Litmusctl is using the `.litmusconfig` config file to manage multiple accounts
@@ -24,9 +24,9 @@ Litmusctl is using the `.litmusconfig` config file to manage multiple accounts
 
 Litmusctl supports both interactive and non-interactive(flag based) modes.
 
-> Only `litmusctl connect agent` command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then litmusctl takes input in an interactive mode.
+> Only `litmusctl connect chaos-delegate` command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then litmusctl takes input in an interactive mode.
 
-### Steps to create an agent
+### Steps to connect a Chaos Delegate
 
 - To setup an account with litmusctl
 
@@ -51,10 +51,10 @@ Password:
 account.username/admin configured
 ```
 
-- To create an agent in a cluster mode
+- To connect a Chaos Delegate in a cluster mode
 
 ```shell
-litmusctl connect agent
+litmusctl connect chaos-delegate
 ```
 
 There will be a list of existing projects displayed on the terminal. Select the desired project by entering the sequence number indicated against it.
@@ -68,13 +68,13 @@ Select a project [Range: 1-1]: 1
 
 Next, select the installation mode based on your requirement by entering the sequence number indicated against it.
 
-Litmusctl can install an agent in two different modes.
+Litmusctl can install an Chaos Delegate in two different modes.
 
-- cluster mode: With this mode, the agent can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode.
+- cluster mode: With this mode, the Chaos Delegate can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode.
 
-- namespace mode: With this mode, the agent can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode.
+- namespace mode: With this mode, the Chaos Delegate can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode.
 
-Note: With namespace mode, the user needs to create the namespace to install the agent as a prerequisite.
+Note: With namespace mode, the user needs to create the namespace to install the Chaos Delegate as a prerequisite.
 
 ```
 Installation Modes:
@@ -86,11 +86,11 @@ Select Mode [Default: cluster] [Range: 1-2]: 1
 🏃 Running prerequisites check....
 🔑 clusterrole ✅
 🔑 clusterrolebinding ✅
-🌟 Sufficient permissions. Installing the Agent...
+🌟 Sufficient permissions. Installing the Chaos Delegate...
 
 ```
 
-Next, enter the details of the new agent.
+Next, enter the details of the new Chaos Delegate.
 
 Fields to be filled in <br />
 
@@ -98,24 +98,24 @@ Fields to be filled in <br />
     <th>Field</th>
     <th>Description</th>
     <tr>
-        <td>Agent Name:</td>
-        <td>Enter a name of the agent which needs to be unique across the project</td>
+        <td>Chaos Delegate Name:</td>
+        <td>Enter a name of the Chaos Delegate which needs to be unique across the project</td>
     </tr>
     <tr>
-        <td>Agent Description:</td>
-        <td>Fill in details about the agent</td>
+        <td>Chaos Delegate Description:</td>
+        <td>Fill in details about the Chaos Delegate</td>
     </tr>
     <tr>
         <td>Skip SSL verification</td>
-        <td>Choose whether agent will skip SSL/TLS verification</td>
+        <td>Choose whether Chaos Delegate will skip SSL/TLS verification</td>
     </tr>
     <tr>
         <td>Node Selector:</td>
-        <td>To deploy the agent on a particular node based on the node selector labels</td>
+        <td>To deploy the Chaos Delegate on a particular node based on the node selector labels</td>
     </tr>
     <tr>
         <td>Platform Name:</td>
-        <td>Enter the platform name on which this agent is hosted. For example, AWS, GCP, Rancher etc.</td>
+        <td>Enter the platform name on which this Chaos Delegate is hosted. For example, AWS, GCP, Rancher etc.</td>
     </tr>
     <tr>
         <td>Enter the namespace:</td>
@@ -128,15 +128,15 @@ Fields to be filled in <br />
 </table>
 
 ```
-Enter the details of the agent
+Enter the details of the Chaos Delegate
 
-Agent Name: New-Agent
+Chaos Delegate Name: New-Chaos-Delegate
 
-Agent Description: This is a new agent
+Chaos Delegate Description: This is a new Chaos Delegate
 
-Do you want Agent to skip SSL/TLS check (Y/N) (Default: N): n
+Do you want Chaos Delegate to skip SSL/TLS check (Y/N) (Default: N): n
 
-Do you want NodeSelector to be added in the agent deployments (Y/N) (Default: N): N
+Do you want NodeSelector to be added in the Chaos Delegate deployments (Y/N) (Default: N): N
 
 Platform List:
 1. AWS
@@ -152,15 +152,15 @@ Enter the namespace (new or existing namespace) [Default: litmus]:
 ```
 
 Once, all these steps are implemented you will be able to see a summary of all the entered fields.
-After verification of these details, you can proceed with the connection of the agent by entering Y. The process of connection might take up to a few seconds.
+After verification of these details, you can proceed with the connection of the Chaos Delegate by entering Y. The process of connection might take up to a few seconds.
 
 ```
 Enter service account [Default: litmus]:
 
 📌 Summary
-Agent Name: New-Agent
-Agent Description: This is a new agent
-Agent SSL/TLS Skip: false
+Chaos Delegate Name: New-Chaos-Delegate
+Chaos Delegate Description: This is a new Chaos Delegate
+Chaos Delegate SSL/TLS Skip: false
 Platform Name: Others
 Namespace:  litmus
 Service Account:  litmus (new)
@@ -168,36 +168,36 @@ Service Account:  litmus (new)
 Installation Mode: cluster
 
 🤷 Do you want to continue with the above details? [Y/N]: Y
-👍 Continuing agent connection!!
+👍 Continuing Chaos Delegate connection!!
 Applying YAML:
 https://preview.litmuschaos.io/api/file/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiMDUyZmFlN2UtZGM0MS00YmU4LWJiYTgtMmM4ZTYyNDFkN2I0In0.i31QQDG92X5nD6P_-7TfeAAarZqLvUTFfnAghJYXPiM.yaml
 
-💡 Connecting agent to ChaosCenter.
-🏃 Agents are running!!
+💡 Connecting Chaos Delegate to ChaosCenter.
+🏃 Chaos Delegates are running!!
 
-🚀 Agent Connection Successful!! 🎉
-👉 Litmus agents can be accessed here: https://preview.litmuschaos.io/targets
+🚀 Chaos Delegate Connection Successful!! 🎉
+👉 Litmus Chaos Delegates can be accessed here: https://preview.litmuschaos.io/targets
 ```
 
-#### Verify the new Agent Connection\*\*
+#### Verify the new Chaos Delegate Connection\*\*
 
-To verify, if the connection process was successful you can view the list of connected agents from the Targets section on your ChaosCenter and ensure that the connected agent is in Active State.
+To verify, if the connection process was successful you can view the list of connected Chaos Delegates from the Targets section on your ChaosCenter and ensure that the connected Chaos Delegate is in Active State.
 
 ---
 
-### Steps to create a Chaos Workflow
+### Steps to create a Chaos Scenario
 
 * To setup an account with litmusctl
 ```shell
 litmusctl config set-account --endpoint="" --username="" --password=""
 ```
 
-* To create a Chaos Workflow by passing a manifest file
+* To create a Chaos Scenario by passing a manifest file
 > Note:
 > * To get `project-id`, apply `litmusctl get projects`
-> * To get `agent-id`, apply `litmusctl get agents --project-id=""`
+> * To get `chaos-delegate-id`, apply `litmusctl get chaos-delegates --project-id=""`
 ```shell
-litmusctl create workflow -f custom-chaos-workflow.yml --project-id="" --agent-id=""
+litmusctl create chaos-scenario -f custom-chaos-scenario.yml --project-id="" --chaos-delegate-id=""
 ```
 
 ---
@@ -274,10 +274,10 @@ PROJECT ID                                PROJECT NAME       CREATEDAT
 7a4a259a-1ae5-4204-ae83-89a8838eaec3      DevOps Project     2021-07-21 14:39:14 +0530 IST
 ```
 
-- To get an overview of the agents available within a project, issue the following command.
+- To get an overview of the Chaos Delegates available within a project, issue the following command.
 
 ```shell
-litmusctl get agents
+litmusctl get chaos-delegates
 
 Enter the Project ID: 50addd40-8767-448c-a91a-5071543a2d8e
 ```
@@ -285,57 +285,57 @@ Enter the Project ID: 50addd40-8767-448c-a91a-5071543a2d8e
 **Output:**
 
 ```
-AGENTID                                AGENTNAME          STATUS     REGISTRATION
-55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE     REGISTERED
-13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE   NOT REGISTERED
+CHAOS DELEGATE ID                      CHAOS DELEGATE NAME    STATUS     REGISTRATION
+55ecc7f2-2754-43aa-8e12-6903e4c6183a   chaos-delegate-1            ACTIVE     REGISTERED
+13dsf3d1-5324-54af-4g23-5331g5v2364f   chaos-delegate-2            INACTIVE   NOT REGISTERED
 ```
 
 
-* To disconnect an agent, issue the following command..
+* To disconnect an Chaos Delegate, issue the following command..
 ```shell
-litmusctl disconnect agent <agent-id> --project-id=""
+litmusctl disconnect chaos-delegate <chaos-delegate-id> --project-id=""
 ```
 
 **Output:**
 
 ```
-🚀 ChaosAgent successfully disconnected.
+🚀 Chaos Delegate successfully disconnected.
 ```
 
 
-* To list the created workflows within a project, issue the following command.
+* To list the created scenarios within a project, issue the following command.
 ```shell
-litmusctl get workflows --project-id=""
+litmusctl get chaos-scenarios --project-id=""
 ```
 
 **Output:**
 
 ```
-WORKFLOW ID                          WORKFLOW NAME                    WORKFLOW TYPE     NEXT SCHEDULE AGENT ID                             AGENT NAME LAST UPDATED BY
-9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-workflow-1627980541 Non Cron Workflow None          f9799723-29f1-454c-b830-ae8ba7ee4c30 Self-Agent admin
+CHAOS SCENARIO ID                         CHAOS SCENARIO NAME                   CHAOS SCENARIO TYPE     NEXT SCHEDULE CHAOS DELEGATE ID                             CHAOS DELEGATE NAME LAST UPDATED BY
+9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-scenario-1627980541 Non Cron Chaos Scenario None          f9799723-29f1-454c-b830-ae8ba7ee4c30 Self-Chaos-delegate admin
 
-Showing 1 of 1 workflows
+Showing 1 of 1 Chaos Scenarios
 ```
 
 
-* To list all the chaos workflow runs within a project, issue the following command.
+* To list all the Chaos Scenario runs within a project, issue the following command.
 ```shell
-litmusctl get workflowruns --project-id=""
+litmusctl get chaos-scenario-runs  --project-id=""
 ```
 
 **Output:**
 
 ```
-WORKFLOW RUN ID                      STATUS  RESILIENCY SCORE WORKFLOW ID                          WORKFLOW NAME                    TARGET AGENT LAST RUN                 EXECUTED BY
-8ceb712c-1ed4-40e6-adc4-01f78d281506 Running 0.00             9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-workflow-1627980541 Self-Agent   June 1 2022, 10:28:02 pm admin
+CHAOS SCENARIO RUN ID                      STATUS  RESILIENCY SCORE CHAOS SCENARIO ID                          CHAOS SCENARIO NAME                    TARGET CHAOS DELEGATE LAST RUN                 EXECUTED BY
+8ceb712c-1ed4-40e6-adc4-01f78d281506 Running 0.00             9433b48c-4ab7-4544-8dab-4a7237619e09 custom-chaos-scenario-1627980541 Self-Chaos-Delegate   June 1 2022, 10:28:02 pm admin
 
-Showing 1 of 1 workflow runs
+Showing 1 of 1 Chaos Scenario runs
 ```
 
 
-* To describe a particular chaos workflow, issue the following command.
+* To describe a particular Chaos Scenario, issue the following command.
 ```shell
-litmusctl describe workflow <workflow-id> --project-id=""
+litmusctl describe chaos-scenario <chaos-scenario-id> --project-id=""
 ```
 
 **Output:**
@@ -347,25 +347,25 @@ metadata:
     creationTimestamp: null
     labels:
         cluster_id: f9799723-29f1-454c-b830-ae8ba7ee4c30
-        subject: custom-chaos-workflow_litmus
+        subject: custom-chaos-scenario_litmus
         workflow_id: 9433b48c-4ab7-4544-8dab-4a7237619e09
         workflows.argoproj.io/controller-instanceid: f9799723-29f1-454c-b830-ae8ba7ee4c30
-    name: custom-chaos-workflow-1627980541
+    name: custom-chaos-scenario-1627980541
     namespace: litmus
 spec:
 ...
 ```
 
 
-* To delete a particular chaos workflow, issue the following command.
+* To delete a particular chaos sceanrio, issue the following command.
 ```shell
-litmusctl delete workflow <workflow-id> --project-id=""
+litmusctl delete delete chaos-scenario <chaos-scenario-id> --project-id=""
 ```
 
 **Output:**
 
 ```
-🚀 ChaosWorkflow successfully deleted.
+🚀 ChaosScenario successfully deleted.
 ```
 
 ---

--- a/Usage_interactive.md
+++ b/Usage_interactive.md
@@ -68,7 +68,7 @@ Select a project [Range: 1-1]: 1
 
 Next, select the installation mode based on your requirement by entering the sequence number indicated against it.
 
-Litmusctl can install an Chaos Delegate in two different modes.
+Litmusctl can install a Chaos Delegate in two different modes.
 
 - cluster mode: With this mode, the Chaos Delegate can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode.
 
@@ -173,7 +173,7 @@ Applying YAML:
 https://preview.litmuschaos.io/api/file/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiMDUyZmFlN2UtZGM0MS00YmU4LWJiYTgtMmM4ZTYyNDFkN2I0In0.i31QQDG92X5nD6P_-7TfeAAarZqLvUTFfnAghJYXPiM.yaml
 
 💡 Connecting Chaos Delegate to ChaosCenter.
-🏃 Chaos Delegates are running!!
+🏃 Chaos Delegate is running!!
 
 🚀 Chaos Delegate Connection Successful!! 🎉
 👉 Litmus Chaos Delegates can be accessed here: https://preview.litmuschaos.io/targets
@@ -303,7 +303,7 @@ litmusctl disconnect chaos-delegate <chaos-delegate-id> --project-id=""
 ```
 
 
-* To list the created scenarios within a project, issue the following command.
+* To list the created Chaos Scenarios within a project, issue the following command.
 ```shell
 litmusctl get chaos-scenarios --project-id=""
 ```
@@ -357,15 +357,15 @@ spec:
 ```
 
 
-* To delete a particular chaos sceanrio, issue the following command.
+* To delete a particular Chaos Scenario, issue the following command.
 ```shell
-litmusctl delete delete chaos-scenario <chaos-scenario-id> --project-id=""
+litmusctl delete chaos-scenario <chaos-scenario-id> --project-id=""
 ```
 
 **Output:**
 
 ```
-🚀 ChaosScenario successfully deleted.
+🚀 Chaos Scenario successfully deleted.
 ```
 
 ---

--- a/pkg/agent/ops.go
+++ b/pkg/agent/ops.go
@@ -28,9 +28,9 @@ import (
 )
 
 func PrintExistingAgents(agent apis.AgentData) {
-	utils.Red.Println("\nAgent with the given name already exists.")
-	// Print agent list if existing agent name is entered twice
-	utils.White_B.Println("\nConnected agents list:")
+	utils.Red.Println("\nChaos Delegate with the given name already exists.")
+	// Print Chaos Delegate list if existing Chaos Delegate name is entered twice
+	utils.White_B.Println("\nConnected Chaos Delegates list:")
 
 	for i := range agent.Data.GetAgent {
 		utils.White_B.Println("-", agent.Data.GetAgent[i].AgentName)
@@ -39,7 +39,7 @@ func PrintExistingAgents(agent apis.AgentData) {
 	utils.White_B.Println("\n❗ Please enter a different name.")
 }
 
-// GetProject display list of projects and returns the project id based on input
+// GetProjectID display list of projects and returns the project id based on input
 func GetProjectID(u apis.ProjectDetails) string {
 	var pid int
 	utils.White_B.Println("Project list:")
@@ -59,7 +59,7 @@ repeat:
 	return u.Data.Projects[pid-1].ID
 }
 
-// GetMode gets mode of agent installation as input
+// GetModeType gets mode of Chaos Delegate installation as input
 func GetModeType() string {
 repeat:
 	var (
@@ -88,22 +88,22 @@ repeat:
 	return utils.DefaultMode
 }
 
-// GetAgentDetails take details of agent as input
+// GetAgentDetails take details of Chaos Delegate as input
 func GetAgentDetails(mode string, pid string, c types.Credentials, kubeconfig *string) (types.Agent, error) {
 	var newAgent types.Agent
 	// Get agent name as input
-	utils.White_B.Println("\nEnter the details of the agent")
-	// Label for goto statement in case of invalid agent name
+	utils.White_B.Println("\nEnter the details of the Chaos Delegate")
+	// Label for goto statement in case of invalid Chaos Delegate name
 
 AGENT_NAME:
-	utils.White_B.Print("\nAgent Name: ")
+	utils.White_B.Print("\nChaos Delegate Name: ")
 	newAgent.AgentName = utils.Scanner()
 	if newAgent.AgentName == "" {
-		utils.Red.Println("⛔ Agent name cannot be empty. Please enter a valid name.")
+		utils.Red.Println("⛔ Chaos Delegate name cannot be empty. Please enter a valid name.")
 		goto AGENT_NAME
 	}
 
-	// Check if agent with the given name already exists
+	// Check if Chaos Delegate with the given name already exists
 	agent, err := apis.GetAgentList(c, pid)
 	if err != nil {
 		return types.Agent{}, err
@@ -123,10 +123,10 @@ AGENT_NAME:
 	}
 
 	// Get agent description as input
-	utils.White_B.Print("\nAgent Description: ")
+	utils.White_B.Print("\nChaos Delegate Description: ")
 	newAgent.Description = utils.Scanner()
 
-	utils.White_B.Print("\nDo you want Agent to skip SSL/TLS check (Y/N) (Default: N): ")
+	utils.White_B.Print("\nDo you want Chaos Delegate to skip SSL/TLS check (Y/N) (Default: N): ")
 	skipSSLDescision := utils.Scanner()
 
 	if strings.ToLower(skipSSLDescision) == "y" {
@@ -135,7 +135,7 @@ AGENT_NAME:
 		newAgent.SkipSSL = false
 	}
 
-	utils.White_B.Print("\nDo you want NodeSelector to be added in the agent deployments (Y/N) (Default: N): ")
+	utils.White_B.Print("\nDo you want NodeSelector to be added in the Chaos Delegate deployments (Y/N) (Default: N): ")
 	nodeSelectorDescision := utils.Scanner()
 
 	if strings.ToLower(nodeSelectorDescision) == "y" {
@@ -147,7 +147,7 @@ AGENT_NAME:
 		}
 	}
 
-	utils.White_B.Print("\nDo you want Tolerations to be added in the agent deployments? (Y/N) (Default: N): ")
+	utils.White_B.Print("\nDo you want Tolerations to be added in the Chaos Delegate deployments? (Y/N) (Default: N): ")
 	tolerationDescision := utils.Scanner()
 
 	if strings.ToLower(tolerationDescision) == "y" {
@@ -241,12 +241,12 @@ func ValidateSAPermissions(mode string, kubeconfig *string) {
 		}
 	}
 
-	utils.White_B.Println("\n🌟 Sufficient permissions. Installing the Agent...")
+	utils.White_B.Println("\n🌟 Sufficient permissions. Installing the Chaos Delegate...")
 }
 
 // Summary display the agent details based on input
 func Summary(agent types.Agent, kubeconfig *string) {
-	utils.White_B.Printf("\n📌 Summary \nAgent Name: %s\nAgent Description: %s\nAgent SSL/TLS Skip: %t\nPlatform Name: %s\n", agent.AgentName, agent.Description, agent.SkipSSL, agent.PlatformName)
+	utils.White_B.Printf("\n📌 Summary \nChaos Delegate Name: %s\nChaos Delegate Description: %s\nChaos Delegate SSL/TLS Skip: %t\nPlatform Name: %s\n", agent.AgentName, agent.Description, agent.SkipSSL, agent.PlatformName)
 	if ok, _ := k8s.NsExists(agent.Namespace, kubeconfig); ok {
 		utils.White_B.Println("Namespace: ", agent.Namespace)
 	} else {
@@ -268,9 +268,9 @@ func ConfirmInstallation() {
 	fmt.Scanln(&descision)
 
 	if strings.ToLower(descision) == "yes" || strings.ToLower(descision) == "y" {
-		utils.White_B.Println("👍 Continuing agent connection!!")
+		utils.White_B.Println("👍 Continuing Chaos Delegate connection!!")
 	} else {
-		utils.Red.Println("✋ Exiting agent connection!!")
+		utils.Red.Println("✋ Exiting Chaos Delegate connection!!")
 		os.Exit(1)
 	}
 }

--- a/pkg/apis/agent.go
+++ b/pkg/apis/agent.go
@@ -46,7 +46,7 @@ type AgentList struct {
 	GetAgent []AgentDetails `json:"listClusters"`
 }
 
-// GetAgentList lists the agent connected to the specified project
+// GetAgentList lists the Chaos Delegate connected to the specified project
 func GetAgentList(c types.Credentials, pid string) (AgentData, error) {
 	query := `{"query":"query{\n  listClusters(projectID: \"` + pid + `\"){\n  clusterID clusterName isActive isRegistered\n  }\n}"}`
 	resp, err := SendRequest(SendRequestParams{Endpoint: c.Endpoint + utils.GQLAPIPath, Token: c.Token}, []byte(query), string(types.Post))
@@ -118,20 +118,20 @@ func ConnectAgent(agent types.Agent, cred types.Credentials) (AgentConnectionDat
 
 	resp, err := SendRequest(SendRequestParams{Endpoint: cred.Endpoint + utils.GQLAPIPath, Token: cred.Token}, []byte(query), string(types.Post))
 	if err != nil {
-		return AgentConnectionData{}, errors.New("Error in registering agent: " + err.Error())
+		return AgentConnectionData{}, errors.New("Error in registering Chaos Delegate: " + err.Error())
 	}
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return AgentConnectionData{}, errors.New("Error in registering agent: " + err.Error())
+		return AgentConnectionData{}, errors.New("Error in registering Chaos Delegate: " + err.Error())
 	}
 
 	if resp.StatusCode == http.StatusOK {
 		var connectAgent AgentConnectionData
 		err = json.Unmarshal(bodyBytes, &connectAgent)
 		if err != nil {
-			return AgentConnectionData{}, errors.New("Error in registering agent: " + err.Error())
+			return AgentConnectionData{}, errors.New("Error in registering Chaos Delegate: " + err.Error())
 		}
 
 		if len(connectAgent.Errors) > 0 {
@@ -163,7 +163,7 @@ type DisconnectAgentGraphQLRequest struct {
 	} `json:"variables"`
 }
 
-// DisconnectAgent sends GraphQL API request for disconnecting ChaosAgent(s).
+// DisconnectAgent sends GraphQL API request for disconnecting Chaos Delegate(s).
 func DisconnectAgent(projectID string, clusterIDs []*string, cred types.Credentials) (DisconnectAgentData, error) {
 
 	var gqlReq DisconnectAgentGraphQLRequest

--- a/pkg/apis/upgrade.go
+++ b/pkg/apis/upgrade.go
@@ -86,7 +86,7 @@ func UpgradeAgent(c context.Context, cred types.Credentials, projectID string, c
 		}
 
 		// To write the manifest data into a temporary file
-		err = ioutil.WriteFile("agent-manifest.yaml", []byte(manifest.Data.GetManifest), 0644)
+		err = ioutil.WriteFile("chaos-delegate-manifest.yaml", []byte(manifest.Data.GetManifest), 0644)
 		if err != nil {
 			return "", err
 		}
@@ -118,7 +118,7 @@ func UpgradeAgent(c context.Context, cred types.Credentials, projectID string, c
 		yamlOutput, err := k8s.ApplyYaml(k8s.ApplyYamlPrams{
 			Token:    cred.Token,
 			Endpoint: cred.Endpoint,
-			YamlPath: "agent-manifest.yaml",
+			YamlPath: "chaos-delegate-manifest.yaml",
 		}, "", true)
 
 		if err != nil {
@@ -126,9 +126,9 @@ func UpgradeAgent(c context.Context, cred types.Credentials, projectID string, c
 		}
 		utils.White.Print("\n", yamlOutput)
 
-		err = os.Remove("agent-manifest.yaml")
+		err = os.Remove("chaos-delegate-manifest.yaml")
 		if err != nil {
-			return "Error removing agent manifest: ", err
+			return "Error removing Chaos Delegate manifest: ", err
 		}
 
 		// Creating a backup for current agent-config in the SUBSCRIBER

--- a/pkg/apis/workflow.go
+++ b/pkg/apis/workflow.go
@@ -81,7 +81,7 @@ func CreateWorkflow(requestData model.ChaosWorkFlowRequest, cred types.Credentia
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return ChaosWorkflowCreationData{}, errors.New("Error in creating workflow: " + err.Error())
+		return ChaosWorkflowCreationData{}, errors.New("Error in creating Chaos Scenario: " + err.Error())
 	}
 
 	if resp.StatusCode == http.StatusOK {
@@ -89,7 +89,7 @@ func CreateWorkflow(requestData model.ChaosWorkFlowRequest, cred types.Credentia
 
 		err = json.Unmarshal(bodyBytes, &createdWorkflow)
 		if err != nil {
-			return ChaosWorkflowCreationData{}, errors.New("Error in creating workflow: " + err.Error())
+			return ChaosWorkflowCreationData{}, errors.New("Error in creating Chaos Scenario: " + err.Error())
 		}
 
 		// Errors present
@@ -191,7 +191,7 @@ func GetWorkflowList(in model.ListWorkflowsRequest, cred types.Credentials) (Wor
 
 		return workflowList, nil
 	} else {
-		return WorkflowListData{}, errors.New("Error while fetching the chaos workflows")
+		return WorkflowListData{}, errors.New("Error while fetching the Chaos Scenarios")
 	}
 }
 
@@ -283,7 +283,7 @@ func GetWorkflowRunsList(in model.ListWorkflowRunsRequest, cred types.Credential
 
 		return workflowRunsList, nil
 	} else {
-		return WorkflowRunsListData{}, errors.New("Error while fetching the chaos workflow runs")
+		return WorkflowRunsListData{}, errors.New("Error while fetching the Chaos Scenario runs")
 	}
 }
 
@@ -362,6 +362,6 @@ func DeleteChaosWorkflow(projectID string, workflowID *string, cred types.Creden
 
 		return deletedWorkflow, nil
 	} else {
-		return DeleteChaosWorkflowData{}, errors.New("Error while deleting the chaos workflow")
+		return DeleteChaosWorkflowData{}, errors.New("Error while deleting the Chaos Scenario")
 	}
 }

--- a/pkg/cmd/connect/agent.go
+++ b/pkg/cmd/connect/agent.go
@@ -35,10 +35,10 @@ var agentCmd = &cobra.Command{
 	Short: `Connect an external Chaos Delegate.
 	Example(s):
 	#connect a Chaos Delegate
-	litmusctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --non-interactive
+	litmusctl connect chaos-delegate --name="new-chaos-delegate" --non-interactive
 
 	#connect a Chaos Delegate within a project
-	litmusctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
+	litmusctl connect chaos-delegate --name="new-chaos-delegate" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 
 	Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 `,

--- a/pkg/cmd/connect/agent.go
+++ b/pkg/cmd/connect/agent.go
@@ -29,16 +29,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// agentCmd represents the agent command
+// agentCmd represents the Chaos Delegate command
 var agentCmd = &cobra.Command{
-	Use: "agent",
-	Short: `Connect an external agent.
+	Use: "chaos-delegate",
+	Short: `Connect an external Chaos Delegate.
 	Example(s):
-	#connect an agent
-	litmusctl connect agent --agent-name="new-agent" --non-interactive
+	#connect a Chaos Delegate
+	litmusctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --non-interactive
 
-	#connect an agent within a project
-	litmusctl connect agent --agent-name="new-agent" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
+	#connect a Chaos Delegate within a project
+	litmusctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 
 	Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 `,
@@ -92,18 +92,18 @@ var agentCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			newAgent.AgentName, err = cmd.Flags().GetString("agent-name")
+			newAgent.AgentName, err = cmd.Flags().GetString("name")
 			utils.PrintError(err)
 
-			newAgent.SkipSSL, err = cmd.Flags().GetBool("skip-agent-ssl")
+			newAgent.SkipSSL, err = cmd.Flags().GetBool("skip-ssl")
 			utils.PrintError(err)
 
 			if newAgent.AgentName == "" {
-				utils.Red.Print("Error: --agent-name flag is empty")
+				utils.Red.Print("Error: --name flag is empty")
 				os.Exit(1)
 			}
 
-			newAgent.Description, err = cmd.Flags().GetString("agent-description")
+			newAgent.Description, err = cmd.Flags().GetString("description")
 			utils.PrintError(err)
 
 			newAgent.PlatformName, err = cmd.Flags().GetString("platform-name")
@@ -114,10 +114,10 @@ var agentCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			newAgent.ClusterType, err = cmd.Flags().GetString("cluster-type")
+			newAgent.ClusterType, err = cmd.Flags().GetString("chaos-delegate-type")
 			utils.PrintError(err)
 			if newAgent.ClusterType == "" {
-				utils.Red.Print("Error: --cluster-type flag is empty")
+				utils.Red.Print("Error: --chaos-delegate-type flag is empty")
 				os.Exit(1)
 			}
 
@@ -236,7 +236,7 @@ var agentCmd = &cobra.Command{
 
 		agent, err := apis.ConnectAgent(newAgent, credentials)
 		if err != nil {
-			utils.Red.Println("\n❌ Agent connection failed: " + err.Error() + "\n")
+			utils.Red.Println("\n❌ Chaos Delegate connection failed: " + err.Error() + "\n")
 			os.Exit(1)
 		}
 		path := fmt.Sprintf("%s/%s/%s.yaml", credentials.Endpoint, utils.ChaosYamlPath, agent.Data.UserAgentReg.Token)
@@ -244,7 +244,7 @@ var agentCmd = &cobra.Command{
 
 		// Print error message in case Data field is null in response
 		if (agent.Data == apis.AgentConnect{}) {
-			utils.White_B.Print("\n🚫 Agent connection failed: " + agent.Errors[0].Message + "\n")
+			utils.White_B.Print("\n🚫 Chaos Delegate connection failed: " + agent.Errors[0].Message + "\n")
 			os.Exit(1)
 		}
 
@@ -265,8 +265,8 @@ var agentCmd = &cobra.Command{
 		// Watch subscriber pod status
 		k8s.WatchPod(k8s.WatchPodParams{Namespace: newAgent.Namespace, Label: utils.ChaosAgentLabel}, &kubeconfig)
 
-		utils.White_B.Println("\n🚀 Agent Connection Successful!! 🎉")
-		utils.White_B.Println("👉 Litmus agents can be accessed here: " + fmt.Sprintf("%s/%s", credentials.Endpoint, utils.ChaosAgentPath))
+		utils.White_B.Println("\n🚀 Chaos Delegate connection successful!! 🎉")
+		utils.White_B.Println("👉 Litmus Chaos Delegates can be accessed here: " + fmt.Sprintf("%s/%s", credentials.Endpoint, utils.ChaosAgentPath))
 	},
 }
 
@@ -277,16 +277,16 @@ func init() {
 	agentCmd.Flags().StringP("kubeconfig", "k", "", "Set to pass kubeconfig file if it is not in the default location ($HOME/.kube/config)")
 	agentCmd.Flags().String("tolerations", "", "Set to pass kubeconfig file if it is not in the default location ($HOME/.kube/config)")
 
-	agentCmd.Flags().String("project-id", "", "Set the project-id to install agent for the particular project. To see the projects, apply litmusctl get projects")
-	agentCmd.Flags().String("installation-mode", "cluster", "Set the installation mode for the kind of agent | Supported=cluster/namespace")
-	agentCmd.Flags().String("agent-name", "", "Set the agent name")
-	agentCmd.Flags().String("agent-description", "---", "Set the agent description")
+	agentCmd.Flags().String("project-id", "", "Set the project-id to install Chaos Delegate for the particular project. To see the projects, apply litmusctl get projects")
+	agentCmd.Flags().String("installation-mode", "cluster", "Set the installation mode for the kind of Chaos Delegate | Supported=cluster/namespace")
+	agentCmd.Flags().String("name", "", "Set the Chaos Delegate name")
+	agentCmd.Flags().String("description", "---", "Set the Chaos Delegate description")
 	agentCmd.Flags().String("platform-name", "Others", "Set the platform name. Supported- AWS/GKE/Openshift/Rancher/Others")
-	agentCmd.Flags().String("cluster-type", "external", "Set the cluster-type to external for external agents | Supported=external/internal")
-	agentCmd.Flags().String("node-selector", "", "Set the node-selector for agent components | Format: \"key1=value1,key2=value2\")")
-	agentCmd.Flags().String("namespace", "litmus", "Set the namespace for the agent installation")
-	agentCmd.Flags().String("service-account", "litmus", "Set the service account to be used by the agent")
-	agentCmd.Flags().Bool("skip-agent-ssl", false, "Set whether agent will skip ssl/tls check (can be used for self-signed certs, if cert is not provided in portal)")
+	agentCmd.Flags().String("chaos-delegate-type", "external", "Set the chaos-delegate-type to external for external Chaos Delegates | Supported=external/internal")
+	agentCmd.Flags().String("node-selector", "", "Set the node-selector for Chaos Delegate components | Format: \"key1=value1,key2=value2\")")
+	agentCmd.Flags().String("namespace", "litmus", "Set the namespace for the Chaos Delegate installation")
+	agentCmd.Flags().String("service-account", "litmus", "Set the service account to be used by the Chaos Delegate")
+	agentCmd.Flags().Bool("skip-ssl", false, "Set whether Chaos Delegate will skip ssl/tls check (can be used for self-signed certs, if cert is not provided in portal)")
 	agentCmd.Flags().Bool("ns-exists", false, "Set the --ns-exists=false if the namespace mentioned in the --namespace flag is not existed else set it to --ns-exists=true | Note: Always set the boolean flag as --ns-exists=Boolean")
 	agentCmd.Flags().Bool("sa-exists", false, "Set the --sa-exists=false if the service-account mentioned in the --service-account flag is not existed else set it to --sa-exists=true | Note: Always set the boolean flag as --sa-exists=Boolean\"\n")
 }

--- a/pkg/cmd/connect/connect.go
+++ b/pkg/cmd/connect/connect.go
@@ -24,11 +24,11 @@ var ConnectCmd = &cobra.Command{
 	Use: "connect",
 	Short: `Connect resources for LitmusChaos agent plane.
 		Examples:
-		#connect an agent
-		litmusctl connect agent --agent-name="new-agent" --non-interactive
+		#connect a Chaos Delegate
+		litmusctl connect chaos-delegate --name="new-chaos-delegate" --non-interactive
 
-		#connect an agent within a project
-		litmusctl connect agent --agent-name="new-agent" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
+		#connect a chaos-delegate within a project
+		litmusctl connect chaos-delegate --name="new-chaos-delegate" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -27,8 +27,8 @@ var CreateCmd = &cobra.Command{
 		#create a project
 		litmusctl create project --name new-proj
 
-		#create a chaos workflow from a file
-		litmusctl create workflow -f workflow.yaml --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --agent-id="d861b650-1549-4574-b2ba-ab754058dd04"
+		#create a Chaos Scenario from a file
+		litmusctl create chaos-scenario -f chaos-scenario.yaml --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --chaos-delegate-id="d861b650-1549-4574-b2ba-ab754058dd04"
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/create/workflow.go
+++ b/pkg/cmd/create/workflow.go
@@ -32,11 +32,11 @@ import (
 
 // workflowCmd represents the project command
 var workflowCmd = &cobra.Command{
-	Use: "workflow",
-	Short: `Create a Chaos Workflow
+	Use: "chaos-scenario",
+	Short: `Create a Chaos Scenario
 	Example:
-	#create a chaos workflow
-	litmusctl create workflow -f workflow.yaml --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --agent-id="1c9c5801-8789-4ac9-bf5f-32649b707a5c"
+	#create a Chaos Scenario
+	litmusctl create chaos-scenario -f chaos-scenario.yaml --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --chaos-delegate-id="1c9c5801-8789-4ac9-bf5f-32649b707a5c"
 
 	Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,
@@ -65,16 +65,16 @@ var workflowCmd = &cobra.Command{
 			}
 		}
 
-		chaosWorkFlowRequest.ClusterID, err = cmd.Flags().GetString("agent-id")
+		chaosWorkFlowRequest.ClusterID, err = cmd.Flags().GetString("chaos-delegate-id")
 		utils.PrintError(err)
 
-		// Handle blank input for agent ID
+		// Handle blank input for Chaos Delegate ID
 		if chaosWorkFlowRequest.ClusterID == "" {
-			utils.White_B.Print("\nEnter the Agent ID: ")
+			utils.White_B.Print("\nEnter the Chaos Delegate ID: ")
 			fmt.Scanln(&chaosWorkFlowRequest.ClusterID)
 
 			if chaosWorkFlowRequest.ClusterID == "" {
-				utils.Red.Println("⛔ Agent ID can't be empty!!")
+				utils.Red.Println("⛔ Chaos Delegate ID can't be empty!!")
 				os.Exit(1)
 			}
 		}
@@ -102,7 +102,7 @@ var workflowCmd = &cobra.Command{
 		// Parse workflow manifest and populate chaosWorkFlowInput
 		err = utils.ParseWorkflowManifest(workflowManifest, &chaosWorkFlowRequest)
 		if err != nil {
-			utils.Red.Println("❌ Error parsing workflow manifest: " + err.Error())
+			utils.Red.Println("❌ Error parsing Chaos Scenario manifest: " + err.Error())
 			os.Exit(1)
 		}
 
@@ -111,22 +111,22 @@ var workflowCmd = &cobra.Command{
 		if err != nil {
 			if (createdWorkflow.Data == apis.CreatedChaosWorkflow{}) {
 				if strings.Contains(err.Error(), "multiple write errors") {
-					utils.Red.Println("\n❌ ChaosWorkflow/" + chaosWorkFlowRequest.WorkflowName + " already exists")
+					utils.Red.Println("\n❌ Chaos Scenario/" + chaosWorkFlowRequest.WorkflowName + " already exists")
 					os.Exit(1)
 				} else {
-					utils.White_B.Print("\n❌ ChaosWorkflow/" + chaosWorkFlowRequest.WorkflowName + " failed to be created: " + err.Error())
+					utils.White_B.Print("\n❌ Chaos Scenario/" + chaosWorkFlowRequest.WorkflowName + " failed to be created: " + err.Error())
 					os.Exit(1)
 				}
 			}
 		}
 
 		// Successful creation
-		utils.White_B.Println("\n🚀 ChaosWorkflow/" + createdWorkflow.Data.CreateChaosWorkflow.WorkflowName + " successfully created 🎉")
+		utils.White_B.Println("\n🚀 ChaosScenario/" + createdWorkflow.Data.CreateChaosWorkflow.WorkflowName + " successfully created 🎉")
 		if createdWorkflow.Data.CreateChaosWorkflow.CronSyntax == "" {
-			utils.White_B.Println("\nThe next run of this workflow will be scheduled immediately.")
+			utils.White_B.Println("\nThe next run of this Chaos Scenario will be scheduled immediately.")
 		} else {
 			utils.White_B.Println(
-				"\nThe next run of this workflow will be scheduled at " +
+				"\nThe next run of this Chaos Scenario will be scheduled at " +
 					cronexpr.MustParse(createdWorkflow.Data.CreateChaosWorkflow.CronSyntax).Next(time.Now()).Format("January 2nd 2006, 03:04:05 pm"))
 		}
 	},
@@ -135,8 +135,7 @@ var workflowCmd = &cobra.Command{
 func init() {
 	CreateCmd.AddCommand(workflowCmd)
 
-	workflowCmd.Flags().String("project-id", "", "Set the project-id to create workflow for the particular project. To see the projects, apply litmusctl get projects")
-	workflowCmd.Flags().String("agent-id", "", "Set the agent-id to create workflow for the particular agent. To see the agents, apply litmusctl get agents")
-
-	workflowCmd.Flags().StringP("file", "f", "", "The manifest file for the workflow")
+	workflowCmd.Flags().String("project-id", "", "Set the project-id to create Chaos Scenario for the particular project. To see the projects, apply litmusctl get projects")
+	workflowCmd.Flags().String("chaos-delegate-id", "", "Set the chaos-delegate-id to create Chaos Scenario for the particular Chaos Delegate. To see the Chaos Delegates, apply litmusctl get chaos-delegates")
+	workflowCmd.Flags().StringP("file", "f", "", "The manifest file for the Chaos Scenario")
 }

--- a/pkg/cmd/create/workflow.go
+++ b/pkg/cmd/create/workflow.go
@@ -121,7 +121,7 @@ var workflowCmd = &cobra.Command{
 		}
 
 		// Successful creation
-		utils.White_B.Println("\n🚀 ChaosScenario/" + createdWorkflow.Data.CreateChaosWorkflow.WorkflowName + " successfully created 🎉")
+		utils.White_B.Println("\n🚀 Chaos Scenario/" + createdWorkflow.Data.CreateChaosWorkflow.WorkflowName + " successfully created 🎉")
 		if createdWorkflow.Data.CreateChaosWorkflow.CronSyntax == "" {
 			utils.White_B.Println("\nThe next run of this Chaos Scenario will be scheduled immediately.")
 		} else {

--- a/pkg/cmd/delete/delete.go
+++ b/pkg/cmd/delete/delete.go
@@ -24,8 +24,8 @@ var DeleteCmd = &cobra.Command{
 	Use: "delete",
 	Short: `Delete resources for LitmusChaos agent plane.
 		Examples:
-		#delete a chaos workflow
-		litmusctl delete workflow c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
+		#delete a Chaos Scenario
+		litmusctl delete chaos-scenario c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/delete/workflow.go
+++ b/pkg/cmd/delete/workflow.go
@@ -25,13 +25,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// workflowCmd represents the workflow command
+// workflowCmd represents the Chaos Scenario command
 var workflowCmd = &cobra.Command{
-	Use: "workflow",
-	Short: `Delete a Chaos Workflow
+	Use: "chaos-scenario",
+	Short: `Delete a Chaos Scenario
 	Example:
-	#delete a chaos workflow
-	litmusctl delete workflow c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
+	#delete a Chaos Scenario
+	litmusctl delete chaos-scenario c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
 
 	Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,
@@ -58,13 +58,13 @@ var workflowCmd = &cobra.Command{
 
 		workflowID := args[0]
 
-		// Handle blank input for workflow ID
+		// Handle blank input for Chaos Scenario ID
 		if workflowID == "" {
-			utils.White_B.Print("\nEnter the Workflow ID: ")
+			utils.White_B.Print("\nEnter the Chaos Scenario ID: ")
 			fmt.Scanln(&workflowID)
 
 			if workflowID == "" {
-				utils.Red.Println("⛔ Workflow ID can't be empty!!")
+				utils.Red.Println("⛔ Chaos Scenario ID can't be empty!!")
 				os.Exit(1)
 			}
 		}
@@ -92,14 +92,14 @@ var workflowCmd = &cobra.Command{
 		// Make API call
 		deletedWorkflow, err := apis.DeleteChaosWorkflow(projectID, &workflowID, credentials)
 		if err != nil {
-			utils.Red.Println("\n❌ Error in deleting ChaosWorkflow: ", err.Error())
+			utils.Red.Println("\n❌ Error in deleting Chaos Scenario: ", err.Error())
 			os.Exit(1)
 		}
 
 		if deletedWorkflow.Data.IsDeleted {
-			utils.White_B.Println("\n🚀 ChaosWorkflow successfully deleted.")
+			utils.White_B.Println("\n🚀 Chaos Scenario successfully deleted.")
 		} else {
-			utils.White_B.Println("\n❌ Failed to delete ChaosWorkflow. Please check if the ID is correct or not.")
+			utils.White_B.Println("\n❌ Failed to delete Chaos Scenario. Please check if the ID is correct or not.")
 		}
 	},
 }
@@ -107,5 +107,5 @@ var workflowCmd = &cobra.Command{
 func init() {
 	DeleteCmd.AddCommand(workflowCmd)
 
-	workflowCmd.Flags().String("project-id", "", "Set the project-id to create workflow for the particular project. To see the projects, apply litmusctl get projects")
+	workflowCmd.Flags().String("project-id", "", "Set the project-id to create Chaos Scenario for the particular project. To see the projects, apply litmusctl get projects")
 }

--- a/pkg/cmd/describe/describe.go
+++ b/pkg/cmd/describe/describe.go
@@ -24,7 +24,7 @@ var DescribeCmd = &cobra.Command{
 	Use: "describe",
 	Short: `Describe resources for LitmusChaos agent plane.
 		Examples:
-		#describe a ChaosScenario
+		#describe a Chaos Scenario
 		litmusctl describe chaos-scenario d861b650-1549-4574-b2ba-ab754058dd04 --project-id="d861b650-1549-4574-b2ba-ab754058dd04"
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag

--- a/pkg/cmd/describe/describe.go
+++ b/pkg/cmd/describe/describe.go
@@ -24,8 +24,8 @@ var DescribeCmd = &cobra.Command{
 	Use: "describe",
 	Short: `Describe resources for LitmusChaos agent plane.
 		Examples:
-		#describe a ChaosWorkflow
-		litmusctl describe workflow d861b650-1549-4574-b2ba-ab754058dd04 --project-id="d861b650-1549-4574-b2ba-ab754058dd04"
+		#describe a ChaosScenario
+		litmusctl describe chaos-scenario d861b650-1549-4574-b2ba-ab754058dd04 --project-id="d861b650-1549-4574-b2ba-ab754058dd04"
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/describe/workflow.go
+++ b/pkg/cmd/describe/workflow.go
@@ -26,11 +26,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// workflowCmd represents the workflow command
+// workflowCmd represents the Chaos Scenario command
 var workflowCmd = &cobra.Command{
-	Use:   "workflow",
-	Short: "Describe a ChaosWorkflow within the project",
-	Long:  `Describe a ChaosWorkflow within the project`,
+	Use:   "chaos-scenario",
+	Short: "Describe a Chaos Scenario within the project",
+	Long:  `Describe a Chaos Scenario within the project`,
 	Run: func(cmd *cobra.Command, args []string) {
 		credentials, err := utils.GetCredentials(cmd)
 		utils.PrintError(err)
@@ -51,13 +51,13 @@ var workflowCmd = &cobra.Command{
 		}
 
 		workflowID := args[0]
-		// Handle blank input for workflow ID
+		// Handle blank input for Chaos Scenario ID
 		if workflowID == "" {
-			utils.White_B.Print("\nEnter the Workflow ID: ")
+			utils.White_B.Print("\nEnter the Chaos Scenario ID: ")
 			fmt.Scanln(&workflowID)
 
 			if workflowID == "" {
-				utils.Red.Println("⛔ Workflow ID can't be empty!!")
+				utils.Red.Println("⛔ Chaos Scenario ID can't be empty!!")
 				os.Exit(1)
 			}
 		}
@@ -69,7 +69,7 @@ var workflowCmd = &cobra.Command{
 
 		yamlManifest, err := yaml.JSONToYAML([]byte(workflow.Data.ListWorkflowDetails.Workflows[0].WorkflowManifest))
 		if err != nil {
-			utils.Red.Println("❌ Error parsing workflow manifest: " + err.Error())
+			utils.Red.Println("❌ Error parsing Chaos Scenario manifest: " + err.Error())
 			os.Exit(1)
 		}
 		utils.PrintInYamlFormat(string(yamlManifest))
@@ -79,5 +79,5 @@ var workflowCmd = &cobra.Command{
 func init() {
 	DescribeCmd.AddCommand(workflowCmd)
 
-	workflowCmd.Flags().String("project-id", "", "Set the project-id to list workflows from the particular project. To see the projects, apply litmusctl get projects")
+	workflowCmd.Flags().String("project-id", "", "Set the project-id to list Chaos Scenarios from the particular project. To see the projects, apply litmusctl get projects")
 }

--- a/pkg/cmd/disconnect/agent.go
+++ b/pkg/cmd/disconnect/agent.go
@@ -28,11 +28,11 @@ import (
 
 // agentCmd represents the agent command
 var agentCmd = &cobra.Command{
-	Use: "agent",
-	Short: `Disconnect a ChaosAgent
+	Use: "chaos-delegate",
+	Short: `Disconnect a Chaos Delegate
 	Example:
-	#disconnect an agent
-	litmusctl disconnect agent c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
+	#disconnect a Chaos Delegate
+	litmusctl disconnect chaos-delegate c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
 
 	Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,
@@ -61,11 +61,11 @@ var agentCmd = &cobra.Command{
 
 		// Handle blank input for agent ID
 		if agentID == "" {
-			utils.White_B.Print("\nEnter the Agent ID: ")
+			utils.White_B.Print("\nEnter the Chaos Delegate ID: ")
 			fmt.Scanln(&agentID)
 
 			if agentID == "" {
-				utils.Red.Println("⛔ Agent ID can't be empty!!")
+				utils.Red.Println("⛔ Chaos Delegate ID can't be empty!!")
 				os.Exit(1)
 			}
 		}
@@ -95,14 +95,14 @@ var agentCmd = &cobra.Command{
 		agentIDs = append(agentIDs, &agentID)
 		disconnectedAgent, err := apis.DisconnectAgent(projectID, agentIDs, credentials)
 		if err != nil {
-			utils.Red.Println("\n❌ Error in disconnecting ChaosAgent: ", err.Error())
+			utils.Red.Println("\n❌ Error in disconnecting Chaos Delegate: ", err.Error())
 			os.Exit(1)
 		}
 
 		if strings.Contains(disconnectedAgent.Data.Message, "Successfully deleted clusters") {
-			utils.White_B.Println("\n🚀 ChaosAgent successfully disconnected.")
+			utils.White_B.Println("\n🚀 Chaos Delegate successfully disconnected.")
 		} else {
-			utils.White_B.Println("\n❌ Failed to disconnect ChaosAgent. Please check if the ID is correct or not.")
+			utils.White_B.Println("\n❌ Failed to disconnect Chaos Delegate. Please check if the ID is correct or not.")
 		}
 	},
 }
@@ -110,5 +110,5 @@ var agentCmd = &cobra.Command{
 func init() {
 	DisconnectCmd.AddCommand(agentCmd)
 
-	agentCmd.Flags().String("project-id", "", "Set the project-id to create workflow for the particular project. To see the projects, apply litmusctl get projects")
+	agentCmd.Flags().String("project-id", "", "Set the project-id to disconnect Chaos Delegate for the particular project. To see the projects, apply litmusctl get projects")
 }

--- a/pkg/cmd/disconnect/disconnect.go
+++ b/pkg/cmd/disconnect/disconnect.go
@@ -24,8 +24,8 @@ var DisconnectCmd = &cobra.Command{
 	Use: "disconnect",
 	Short: `Disconnect resources for LitmusChaos agent plane.
 		Examples:
-		#disconnect an agent
-		litmusctl disconnect agent c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
+		#disconnect a Chaos Delegate
+		litmusctl disconnect chaos-delegate c520650e-7cb6-474c-b0f0-4df07b2b025b --project-id=c520650e-7cb6-474c-b0f0-4df07b2b025b
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/get/agents.go
+++ b/pkg/cmd/get/agents.go
@@ -27,9 +27,9 @@ import (
 
 // agentsCmd represents the agents command
 var agentsCmd = &cobra.Command{
-	Use:   "agents",
-	Short: "Display list of agents within the project",
-	Long:  `Display list of agents within the project`,
+	Use:   "chaos-delegates",
+	Short: "Display list of Chaos Delegates within the project",
+	Long:  `Display list of Chaos Delegates within the project`,
 	Run: func(cmd *cobra.Command, args []string) {
 		credentials, err := utils.GetCredentials(cmd)
 		utils.PrintError(err)
@@ -63,7 +63,7 @@ var agentsCmd = &cobra.Command{
 		case "":
 
 			writer := tabwriter.NewWriter(os.Stdout, 4, 8, 1, '\t', 0)
-			utils.White_B.Fprintln(writer, "AGENT ID \tAGENT NAME\tSTATUS\tREGISTRATION\t")
+			utils.White_B.Fprintln(writer, "CHAOS DELEGATE ID \tCHAOS DELEGATE NAME\tSTATUS\tREGISTRATION\t")
 
 			for _, agent := range agents.Data.GetAgent {
 				var status string

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -26,14 +26,14 @@ var GetCmd = &cobra.Command{
 		#get list of projects accessed by the user
 		litmusctl get projects
 
-		#get list of agents within the project
-		litmusctl get agents --project-id=""
+		#get list of Chaos Delegates within the project
+		litmusctl get chaos-delegates --project-id=""
 
-		#get list of chaos workflows
-		litmusctl get workflows --project-id=""
+		#get list of chaos Chaos Scenarios
+		litmusctl get chaos-sceanrios --project-id=""
 
-		#get list of chaos workflow runs
-		litmusctl get workflowruns --project-id=""
+		#get list of Chaos Scenario runs
+		litmusctl get chaos-scenario-runs --project-id=""
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/get/workflowruns.go
+++ b/pkg/cmd/get/workflowruns.go
@@ -28,11 +28,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// workflowRunsCmd represents the workflow runs command
+// workflowRunsCmd represents the Chaos Scenario runs command
 var workflowRunsCmd = &cobra.Command{
-	Use:   "workflowruns",
-	Short: "Display list of workflow runs within the project",
-	Long:  `Display list of workflow runs within the project`,
+	Use:   "chaos-scenario-runs",
+	Short: "Display list of Chaos Scenario runs within the project",
+	Long:  `Display list of Chaos Scenario runs within the project`,
 	Run: func(cmd *cobra.Command, args []string) {
 		credentials, err := utils.GetCredentials(cmd)
 		utils.PrintError(err)
@@ -74,7 +74,7 @@ var workflowRunsCmd = &cobra.Command{
 		case "":
 
 			writer := tabwriter.NewWriter(os.Stdout, 4, 8, 1, '\t', 0)
-			utils.White_B.Fprintln(writer, "WORKFLOW RUN ID\tSTATUS\tRESILIENCY SCORE\tWORKFLOW ID\tWORKFLOW NAME\tTARGET AGENT\tLAST RUN\tEXECUTED BY")
+			utils.White_B.Fprintln(writer, "CHAOS SCENARIO RUN ID\tSTATUS\tRESILIENCY SCORE\tCHAOS SCENARIO ID\tCHAOS SCENARIO NAME\tTARGET CHAOS DELEGATE\tLAST RUN\tEXECUTED BY")
 
 			for _, workflowRun := range workflowRuns.Data.ListWorkflowRunsDetails.WorkflowRuns {
 
@@ -92,9 +92,9 @@ var workflowRunsCmd = &cobra.Command{
 			}
 
 			if listAllWorkflowRuns || (workflowRuns.Data.ListWorkflowRunsDetails.TotalNoOfWorkflowRuns <= listWorkflowRunsRequest.Pagination.Limit) {
-				utils.White_B.Fprintln(writer, fmt.Sprintf("\nShowing %d of %d workflow runs", workflowRuns.Data.ListWorkflowRunsDetails.TotalNoOfWorkflowRuns, workflowRuns.Data.ListWorkflowRunsDetails.TotalNoOfWorkflowRuns))
+				utils.White_B.Fprintln(writer, fmt.Sprintf("\nShowing %d of %d Chaos Scenario runs", workflowRuns.Data.ListWorkflowRunsDetails.TotalNoOfWorkflowRuns, workflowRuns.Data.ListWorkflowRunsDetails.TotalNoOfWorkflowRuns))
 			} else {
-				utils.White_B.Fprintln(writer, fmt.Sprintf("\nShowing %d of %d workflow runs", listWorkflowRunsRequest.Pagination.Limit, workflowRuns.Data.ListWorkflowRunsDetails.TotalNoOfWorkflowRuns))
+				utils.White_B.Fprintln(writer, fmt.Sprintf("\nShowing %d of %d Chaos Scenario runs", listWorkflowRunsRequest.Pagination.Limit, workflowRuns.Data.ListWorkflowRunsDetails.TotalNoOfWorkflowRuns))
 			}
 
 			writer.Flush()
@@ -105,9 +105,9 @@ var workflowRunsCmd = &cobra.Command{
 func init() {
 	GetCmd.AddCommand(workflowRunsCmd)
 
-	workflowRunsCmd.Flags().String("project-id", "", "Set the project-id to list workflows from the particular project. To see the projects, apply litmusctl get projects")
-	workflowRunsCmd.Flags().Int("count", 30, "Set the count of workflow runs to display. Default value is 30")
-	workflowRunsCmd.Flags().BoolP("all", "A", false, "Set to true to display all workflow runs")
+	workflowRunsCmd.Flags().String("project-id", "", "Set the project-id to list Chaos Scenarios from the particular project. To see the projects, apply litmusctl get projects")
+	workflowRunsCmd.Flags().Int("count", 30, "Set the count of Chaos Scenario runs to display. Default value is 30")
+	workflowRunsCmd.Flags().BoolP("all", "A", false, "Set to true to display all Chaos Scenario runs")
 
 	workflowRunsCmd.Flags().StringP("output", "o", "", "Output format. One of:\njson|yaml")
 }

--- a/pkg/cmd/get/workflows.go
+++ b/pkg/cmd/get/workflows.go
@@ -28,11 +28,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// workflowsCmd represents the workflows command
+// workflowsCmd represents the Chaos Scenarios command
 var workflowsCmd = &cobra.Command{
-	Use:   "workflows",
-	Short: "Display list of workflows within the project",
-	Long:  `Display list of workflows within the project`,
+	Use:   "chaos-scenarios",
+	Short: "Display list of Chaos Scenarios within the project",
+	Long:  `Display list of Chaos Scenarios within the project`,
 	Run: func(cmd *cobra.Command, args []string) {
 		credentials, err := utils.GetCredentials(cmd)
 		utils.PrintError(err)
@@ -59,7 +59,7 @@ var workflowsCmd = &cobra.Command{
 		}
 
 		listWorkflowsRequest.Filter = &model.WorkflowFilterInput{}
-		agentName, err := cmd.Flags().GetString("agent")
+		agentName, err := cmd.Flags().GetString("chaos-delegate")
 		utils.PrintError(err)
 		listWorkflowsRequest.Filter.ClusterName = &agentName
 
@@ -79,24 +79,24 @@ var workflowsCmd = &cobra.Command{
 		case "":
 
 			writer := tabwriter.NewWriter(os.Stdout, 4, 8, 1, '\t', 0)
-			utils.White_B.Fprintln(writer, "WORKFLOW ID\tWORKFLOW NAME\tWORKFLOW TYPE\tNEXT SCHEDULE\tAGENT ID\tAGENT NAME\tLAST UPDATED BY")
+			utils.White_B.Fprintln(writer, "CHAOS SCENARIO ID\tCHAOS SCENARIO NAME\tCHAOS SCENARIO TYPE\tNEXT SCHEDULE\tCHAOS DELEGATE ID\tCHAOS DELEGATE NAME\tLAST UPDATED BY")
 
 			for _, workflow := range workflows.Data.ListWorkflowDetails.Workflows {
 				if workflow.CronSyntax != "" {
 					utils.White.Fprintln(
 						writer,
-						workflow.WorkflowID+"\t"+workflow.WorkflowName+"\tCron Workflow\t"+cronexpr.MustParse(workflow.CronSyntax).Next(time.Now()).Format("January 2 2006, 03:04:05 pm")+"\t"+workflow.ClusterID+"\t"+workflow.ClusterName+"\t"+*workflow.LastUpdatedBy)
+						workflow.WorkflowID+"\t"+workflow.WorkflowName+"\tCron Chaos Scenario\t"+cronexpr.MustParse(workflow.CronSyntax).Next(time.Now()).Format("January 2 2006, 03:04:05 pm")+"\t"+workflow.ClusterID+"\t"+workflow.ClusterName+"\t"+*workflow.LastUpdatedBy)
 				} else {
 					utils.White.Fprintln(
 						writer,
-						workflow.WorkflowID+"\t"+workflow.WorkflowName+"\tNon Cron Workflow\tNone\t"+workflow.ClusterID+"\t"+workflow.ClusterName+"\t"+*workflow.LastUpdatedBy)
+						workflow.WorkflowID+"\t"+workflow.WorkflowName+"\tNon Cron Chaos Scenario\tNone\t"+workflow.ClusterID+"\t"+workflow.ClusterName+"\t"+*workflow.LastUpdatedBy)
 				}
 			}
 
 			if listAllWorkflows || (workflows.Data.ListWorkflowDetails.TotalNoOfWorkflows <= listWorkflowsRequest.Pagination.Limit) {
-				utils.White_B.Fprintln(writer, fmt.Sprintf("\nShowing %d of %d workflows", workflows.Data.ListWorkflowDetails.TotalNoOfWorkflows, workflows.Data.ListWorkflowDetails.TotalNoOfWorkflows))
+				utils.White_B.Fprintln(writer, fmt.Sprintf("\nShowing %d of %d Chaos Scenarios", workflows.Data.ListWorkflowDetails.TotalNoOfWorkflows, workflows.Data.ListWorkflowDetails.TotalNoOfWorkflows))
 			} else {
-				utils.White_B.Fprintln(writer, fmt.Sprintf("\nShowing %d of %d workflows", listWorkflowsRequest.Pagination.Limit, workflows.Data.ListWorkflowDetails.TotalNoOfWorkflows))
+				utils.White_B.Fprintln(writer, fmt.Sprintf("\nShowing %d of %d Chaos Scenarios", listWorkflowsRequest.Pagination.Limit, workflows.Data.ListWorkflowDetails.TotalNoOfWorkflows))
 			}
 			writer.Flush()
 		}
@@ -106,10 +106,10 @@ var workflowsCmd = &cobra.Command{
 func init() {
 	GetCmd.AddCommand(workflowsCmd)
 
-	workflowsCmd.Flags().String("project-id", "", "Set the project-id to list workflows from the particular project. To see the projects, apply litmusctl get projects")
-	workflowsCmd.Flags().Int("count", 30, "Set the count of workflows to display. Default value is 30")
-	workflowsCmd.Flags().Bool("all", false, "Set to true to display all workflows")
-	workflowsCmd.Flags().StringP("agent", "A", "", "Set the agent name to display all workflows targeted towards that particular agent.")
+	workflowsCmd.Flags().String("project-id", "", "Set the project-id to list Chaos Scenarios from the particular project. To see the projects, apply litmusctl get projects")
+	workflowsCmd.Flags().Int("count", 30, "Set the count of Chaos Scenarios to display. Default value is 30")
+	workflowsCmd.Flags().Bool("all", false, "Set to true to display all Chaos Scenarios")
+	workflowsCmd.Flags().StringP("chaos-delegate", "A", "", "Set the Chaos Delegate name to display all Chaos Scenarios targeted towards that particular Chaos Delegate.")
 
 	workflowsCmd.Flags().StringP("output", "o", "", "Output format. One of:\njson|yaml")
 }

--- a/pkg/cmd/upgrade/agent.go
+++ b/pkg/cmd/upgrade/agent.go
@@ -26,7 +26,7 @@ import (
 
 // createCmd represents the create command
 var agentCmd = &cobra.Command{
-	Use:   "agent",
+	Use:   "chaos-delegate",
 	Short: `Upgrades the LitmusChaos agent plane.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		credentials, err := utils.GetCredentials(cmd)
@@ -40,11 +40,11 @@ var agentCmd = &cobra.Command{
 			fmt.Scanln(&projectID)
 		}
 
-		cluster_id, err := cmd.Flags().GetString("cluster-id")
+		cluster_id, err := cmd.Flags().GetString("chaos-delegate-id")
 		utils.PrintError(err)
 
 		if cluster_id == "" {
-			utils.White_B.Print("\nEnter the cluster ID: ")
+			utils.White_B.Print("\nEnter the Chaos Delegate ID: ")
 			fmt.Scanln(&cluster_id)
 		}
 
@@ -61,5 +61,5 @@ var agentCmd = &cobra.Command{
 func init() {
 	UpgradeCmd.AddCommand(agentCmd)
 	agentCmd.Flags().String("project-id", "", "Enter the project ID")
-	agentCmd.Flags().String("cluster-id", "", "Enter the cluster ID")
+	agentCmd.Flags().String("chaos-delegate-id", "", "Enter the Chaos Delegate ID")
 }

--- a/pkg/cmd/upgrade/upgrade.go
+++ b/pkg/cmd/upgrade/upgrade.go
@@ -23,8 +23,8 @@ import (
 var UpgradeCmd = &cobra.Command{
 	Use: "upgrade",
 	Short: `Examples:
-		#upgrade version of your agent
-		litmusctl upgrade agent --cluster-id="4cc25543-36c8-4373-897b-2e5dbbe87bcf" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
+		#upgrade version of your Chaos Delegate
+		litmusctl upgrade chaos-delegate --chaos-delegate-id="4cc25543-36c8-4373-897b-2e5dbbe87bcf" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 
 		Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/k8s/operations.go
+++ b/pkg/k8s/operations.go
@@ -153,7 +153,7 @@ start:
 	}
 	if ok {
 		if podExists(podExistsParams{namespace, label}, kubeconfig) {
-			utils.Red.Println("\n🚫 There is an Chaos Delegate already present in this namespace. Please enter a different namespace")
+			utils.Red.Println("\n🚫 There is a Chaos Delegate already present in this namespace. Please enter a different namespace")
 			goto start
 		} else {
 			nsExists = true
@@ -194,7 +194,7 @@ func WatchPod(params WatchPodParams, kubeconfig *string) {
 		}
 		utils.White_B.Println("💡 Connecting Chaos Delegate to ChaosCenter.")
 		if p.Status.Phase == "Running" {
-			utils.White_B.Println("🏃 Chaos Delegates are running!!")
+			utils.White_B.Println("🏃 Chaos Delegate is running!!")
 			watch.Stop()
 			break
 		}

--- a/pkg/k8s/operations.go
+++ b/pkg/k8s/operations.go
@@ -153,7 +153,7 @@ start:
 	}
 	if ok {
 		if podExists(podExistsParams{namespace, label}, kubeconfig) {
-			utils.Red.Println("\n🚫 There is an agent already present in this namespace. Please enter a different namespace")
+			utils.Red.Println("\n🚫 There is an Chaos Delegate already present in this namespace. Please enter a different namespace")
 			goto start
 		} else {
 			nsExists = true
@@ -192,9 +192,9 @@ func WatchPod(params WatchPodParams, kubeconfig *string) {
 		if !ok {
 			log.Fatal("unexpected type")
 		}
-		utils.White_B.Println("💡 Connecting agent to ChaosCenter.")
+		utils.White_B.Println("💡 Connecting Chaos Delegate to ChaosCenter.")
 		if p.Status.Phase == "Running" {
-			utils.White_B.Println("🏃 Agents are running!!")
+			utils.White_B.Println("🏃 Chaos Delegates are running!!")
 			watch.Stop()
 			break
 		}
@@ -294,11 +294,11 @@ func ApplyYaml(params ApplyYamlPrams, kubeconfig string, isLocal bool) (output s
 		if err != nil {
 			return "", err
 		}
-		err = ioutil.WriteFile("agent-manifest.yaml", resp_body, 0644)
+		err = ioutil.WriteFile("chaos-delegate-manifest.yaml", resp_body, 0644)
 		if err != nil {
 			return "", err
 		}
-		path = "agent-manifest.yaml"
+		path = "chaos-delegate-manifest.yaml"
 	}
 
 	args := []string{"kubectl", "apply", "-f", path}


### PR DESCRIPTION
Updated logs and commands with new terminology:

```
litmusctl connect agent -> litmusctl connect chaos-delegate
litmusctl disconnect agent -> litmusctl disconnect chaos-delegate
litmusctl get agents -> litmusctl get chaos-delegates
litmusctl create workflow -> litmusctl create chaos-scenario
litmusctl delete workflow -> litmusctl delete chaos-scenario
litmusctl describe workflow -> litmusctl describe chaos-scenario
litmusctl get workflows -> litmusctl get chaos-scenarios
litmusctl get workflowruns -> litmusctl get chaos-scenario-runs 
litmusctl upgrade agent -> litmusctl upgrade chaos-delegate
```

Signed-off-by: Sarthak Jain <sarthak.jain@harness.io>