### PR TITLE
Add .exe extension to binaries on Windows

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,9 +35,14 @@ do
         exit 1
     fi
 
+    bin_name='litmusctl'
+    if [ "$GOOS" == 'windows' ]; then
+      bin_name='litmusctl.exe'
+    fi
+
     cd platforms-$tag
-    mv $output_name litmusctl
-    tar -czvf $output_name-$tag.tar.gz litmusctl
-    rm -rf litmusctl
+    mv $output_name $bin_name
+    tar -czvf $output_name-$tag.tar.gz $bin_name
+    rm -rf $bin_name
     cd ..
 done


### PR DESCRIPTION
The binaries available for download for Windows currently ship the binary as `litmusctl` (with no extension). While this is expected on Linux/macOS (where executables have no extension), it seems that Windows has trouble running/recognizing executable files that have no extension. Windows users currently need to rename the file manually to be able to execute it.

This PR modifies the build script to add `.exe` extension for Windows build artifacts where it is expected.