### PR TITLE
Avoid panic during platform discovery with no nodes

### DIFF
--- a/pkg/agent/platform.go
+++ b/pkg/agent/platform.go
@@ -87,7 +87,7 @@ func IsAWSPlatform(kubeconfig *string) (bool, error) {
 		return false, err
 	}
 	nodeList, err := clientset.CoreV1().Nodes().List(context.TODO(), v1.ListOptions{})
-	if err != nil {
+	if err != nil || len(nodeList.Items) == 0 {
 		return false, err
 	}
 	if strings.HasPrefix(nodeList.Items[0].Spec.ProviderID, utils.AWSIdentifier) {
@@ -115,7 +115,7 @@ func IsGKEPlatform(kubeconfig *string) (bool, error) {
 		return false, err
 	}
 	nodeList, err := clientset.CoreV1().Nodes().List(context.TODO(), v1.ListOptions{})
-	if err != nil {
+	if err != nil || len(nodeList.Items) == 0 {
 		return false, err
 	}
 	if strings.HasPrefix(nodeList.Items[0].Spec.ProviderID, utils.GKEIdentifier) {


### PR DESCRIPTION
When attempting to install a ChaosDelegate onto a cluster with no nodes, the automatic platform detection methods for AWS and GKE will panic due to trying to access the first element of a zero-length slice.

This fix assumes that it is intended to allow users to install a ChaosDelegate into a cluster with no nodes. Alternatively, if this is not the case, another solution is to add a check for nodes existence before anything else.