### PR TITLE
Fix tolerations help text in ChaosDelegate connection

### DIFF
--- a/pkg/cmd/connect/agent.go
+++ b/pkg/cmd/connect/agent.go
@@ -281,7 +281,7 @@ func init() {
 
 	agentCmd.Flags().BoolP("non-interactive", "n", false, "Set it to true for non interactive mode | Note: Always set the boolean flag as --non-interactive=Boolean")
 	agentCmd.Flags().StringP("kubeconfig", "k", "", "Set to pass kubeconfig file if it is not in the default location ($HOME/.kube/config)")
-	agentCmd.Flags().String("tolerations", "", "Set to pass kubeconfig file if it is not in the default location ($HOME/.kube/config)")
+	agentCmd.Flags().String("tolerations", "", "Set the tolerations for Chaos Delegate components | Format: '[{\"key\":\"key1\",\"value\":\"value1\",\"operator\":\"Exist\",\"effect\":\"NoSchedule\",\"tolerationSeconds\":30}]'")
 
 	agentCmd.Flags().String("project-id", "", "Set the project-id to install Chaos Delegate for the particular project. To see the projects, apply litmusctl get projects")
 	agentCmd.Flags().String("installation-mode", "cluster", "Set the installation mode for the kind of Chaos Delegate | Supported=cluster/namespace")


### PR DESCRIPTION
The current help text for `--tolerations` is duplicated from the `--kubeconfig` option right before it. This PR sets appropriate help text for the flag, with an example based on the definition of the `Toleration` struct:
https://github.com/litmuschaos/litmusctl/blob/eaf8030d76da8f7e0f6642131daae4cb60a611ef/pkg/types/agent_types.go#L34-L40