### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get tag
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
+        run: echo "branch=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: tag
 
       - name: Building litmusctl


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Resolve #141 

Update `.github/workflows/push.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
```

**TO-BE**

```yaml
run: echo "branch=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
```