### PR TITLE
Add auto completion for parameters values  && args

### DIFF
--- a/pkg/cmd/connect/infra.go
+++ b/pkg/cmd/connect/infra.go
@@ -17,9 +17,11 @@ package connect
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/litmuschaos/litmusctl/pkg/apis/environment"
 	"github.com/litmuschaos/litmusctl/pkg/apis/infrastructure"
-	"os"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 
 	"github.com/litmuschaos/litmusctl/pkg/apis"
 	"github.com/litmuschaos/litmusctl/pkg/k8s"
@@ -283,4 +285,9 @@ func init() {
 	infraCmd.Flags().Bool("skip-ssl", false, "Set whether Chaos infra will skip ssl/tls check (can be used for self-signed certs, if cert is not provided in portal)")
 	infraCmd.Flags().Bool("ns-exists", false, "Set the --ns-exists=false if the namespace mentioned in the --namespace flag is not existed else set it to --ns-exists=true | Note: Always set the boolean flag as --ns-exists=Boolean")
 	infraCmd.Flags().Bool("sa-exists", false, "Set the --sa-exists=false if the service-account mentioned in the --service-account flag is not existed else set it to --sa-exists=true | Note: Always set the boolean flag as --sa-exists=Boolean\"\n")
+
+	infraCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+	infraCmd.RegisterFlagCompletionFunc("installation-mode", completion.InstallModeTypeFlagCompletion)
+	infraCmd.RegisterFlagCompletionFunc("platform-name", completion.PlatformNameFlagCompletion)
+	infraCmd.RegisterFlagCompletionFunc("chaos-infra-type", completion.ChaosInfraTypeFlagCompletion)
 }

--- a/pkg/cmd/create/environment.go
+++ b/pkg/cmd/create/environment.go
@@ -17,13 +17,15 @@ package create
 
 import (
 	"fmt"
+	"os"
+
 	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
 	"github.com/litmuschaos/litmusctl/pkg/apis"
 	"github.com/litmuschaos/litmusctl/pkg/apis/environment"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 	"github.com/litmuschaos/litmusctl/pkg/ops"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // environmentCmd represents the Chaos infra command
@@ -155,4 +157,8 @@ func init() {
 	environmentCmd.Flags().String("type", "NON_PROD", "Set the installation mode for the kind of Chaos infra | Supported=cluster/namespace")
 	environmentCmd.Flags().String("name", "", "Set the Chaos infra name")
 	environmentCmd.Flags().String("description", "---", "Set the Chaos infra description")
+
+	environmentCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+	environmentCmd.RegisterFlagCompletionFunc("type", completion.InstallModeTypeFlagCompletion)
+
 }

--- a/pkg/cmd/create/experiment.go
+++ b/pkg/cmd/create/experiment.go
@@ -17,12 +17,14 @@ package create
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
 	"github.com/litmuschaos/litmusctl/pkg/apis"
 	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
-	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -145,4 +147,8 @@ func init() {
 	experimentCmd.Flags().String("chaos-infra-id", "", "Set the chaos-infra-id to create Chaos Experiment for the particular Chaos Infrastructure. To see the Chaos Infrastructures, apply litmusctl get chaos-infra")
 	experimentCmd.Flags().StringP("file", "f", "", "The manifest file for the Chaos Experiment")
 	experimentCmd.Flags().StringP("description", "d", "", "The Description for the Chaos Experiment")
+
+	experimentCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+	experimentCmd.RegisterFlagCompletionFunc("chaos-infra-id", completion.ChaosInfraFlagCompletion)
+
 }

--- a/pkg/cmd/delete/experiment.go
+++ b/pkg/cmd/delete/experiment.go
@@ -17,8 +17,10 @@ package delete
 
 import (
 	"fmt"
-	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
 	"os"
+
+	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 
 	"github.com/litmuschaos/litmusctl/pkg/apis"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
@@ -36,7 +38,7 @@ var experimentCmd = &cobra.Command{
 
 	Note: The default location of the config file is $HOME/.litmusconfig, and can be overridden by a --config flag
 	`,
-	Args: cobra.ExactArgs(1),
+	ValidArgsFunction: completion.ExperimentIDCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		// Fetch user credentials
@@ -109,4 +111,6 @@ func init() {
 	DeleteCmd.AddCommand(experimentCmd)
 
 	experimentCmd.Flags().String("project-id", "", "Set the project-id to create Chaos Experiment for the particular project. To see the projects, apply litmusctl get projects")
+	experimentCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+
 }

--- a/pkg/cmd/describe/experiment.go
+++ b/pkg/cmd/describe/experiment.go
@@ -17,9 +17,11 @@ package describe
 
 import (
 	"fmt"
-	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
 	"os"
 	"strings"
+
+	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 
 	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
@@ -29,9 +31,11 @@ import (
 
 // experimentCmd represents the Chaos Experiment command
 var experimentCmd = &cobra.Command{
-	Use:   "chaos-experiment",
-	Short: "Describe a Chaos Experiment within the project",
-	Long:  `Describe a Chaos Experiment within the project`,
+	Use:               "chaos-experiment",
+	Short:             "Describe a Chaos Experiment within the project",
+	Long:              `Describe a Chaos Experiment within the project`,
+	ValidArgsFunction: completion.ExperimentIDCompletion,
+
 	Run: func(cmd *cobra.Command, args []string) {
 		credentials, err := utils.GetCredentials(cmd)
 		utils.PrintError(err)
@@ -96,4 +100,6 @@ func init() {
 	DescribeCmd.AddCommand(experimentCmd)
 
 	experimentCmd.Flags().String("project-id", "", "Set the project-id to list Chaos Experiments from the particular project. To see the projects, apply litmusctl get projects")
+	experimentCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+
 }

--- a/pkg/cmd/disconnect/infra.go
+++ b/pkg/cmd/disconnect/infra.go
@@ -17,9 +17,11 @@ package disconnect
 
 import (
 	"fmt"
-	"github.com/litmuschaos/litmusctl/pkg/apis/infrastructure"
 	"os"
 	"strings"
+
+	"github.com/litmuschaos/litmusctl/pkg/apis/infrastructure"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 
 	"github.com/litmuschaos/litmusctl/pkg/apis"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
@@ -114,4 +116,6 @@ func init() {
 	DisconnectCmd.AddCommand(infraCmd)
 
 	infraCmd.Flags().String("project-id", "", "Set the project-id to disconnect Chaos Infrastructure for the particular project. To see the projects, apply litmusctl get projects")
+	infraCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+
 }

--- a/pkg/cmd/get/experimentruns.go
+++ b/pkg/cmd/get/experimentruns.go
@@ -17,12 +17,14 @@ package get
 
 import (
 	"fmt"
-	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
 	"os"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 
 	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
@@ -120,4 +122,8 @@ func init() {
 	experimentRunsCmd.Flags().BoolP("all", "A", false, "Set to true to display all Chaos Experiments runs")
 
 	experimentRunsCmd.Flags().StringP("output", "o", "", "Output format. One of:\njson|yaml")
+
+	experimentRunsCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+	experimentRunsCmd.RegisterFlagCompletionFunc("output", completion.OutputFlagCompletion)
+
 }

--- a/pkg/cmd/get/experiments.go
+++ b/pkg/cmd/get/experiments.go
@@ -17,11 +17,13 @@ package get
 
 import (
 	"fmt"
-	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
 	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 
 	"github.com/gorhill/cronexpr"
 	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
@@ -121,4 +123,9 @@ func init() {
 	experimentsCmd.Flags().StringP("chaos-infra", "A", "", "Set the Chaos Infrastructure name to display all Chaos experiments targeted towards that particular Chaos Infrastructure.")
 
 	experimentsCmd.Flags().StringP("output", "o", "", "Output format. One of:\njson|yaml")
+
+	experimentsCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+	experimentsCmd.RegisterFlagCompletionFunc("chaos-infra", completion.ChaosInfraFlagCompletion)
+	experimentsCmd.RegisterFlagCompletionFunc("output", completion.OutputFlagCompletion)
+
 }

--- a/pkg/cmd/get/infra.go
+++ b/pkg/cmd/get/infra.go
@@ -17,11 +17,13 @@ package get
 
 import (
 	"fmt"
-	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
-	"github.com/litmuschaos/litmusctl/pkg/apis/infrastructure"
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
+	"github.com/litmuschaos/litmusctl/pkg/apis/infrastructure"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 
 	"github.com/litmuschaos/litmusctl/pkg/utils"
 	"github.com/spf13/cobra"
@@ -94,4 +96,8 @@ func init() {
 	InfraCmd.Flags().String("project-id", "", "Set the project-id. To retrieve projects. Apply `litmusctl get projects`")
 
 	InfraCmd.Flags().StringP("output", "o", "", "Output format. One of:\njson|yaml")
+
+	InfraCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+	InfraCmd.RegisterFlagCompletionFunc("output", completion.OutputFlagCompletion)
+
 }

--- a/pkg/cmd/get/projects.go
+++ b/pkg/cmd/get/projects.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/litmuschaos/litmusctl/pkg/apis"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -66,4 +67,6 @@ func init() {
 	GetCmd.AddCommand(projectsCmd)
 
 	projectsCmd.Flags().StringP("output", "o", "", "Output format. One of:\njson|yaml")
+	projectsCmd.RegisterFlagCompletionFunc("output", completion.OutputFlagCompletion)
+
 }

--- a/pkg/cmd/run/experiment.go
+++ b/pkg/cmd/run/experiment.go
@@ -17,12 +17,14 @@ package run
 
 import (
 	"fmt"
-	"github.com/litmuschaos/litmusctl/pkg/apis"
-	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
-	"github.com/litmuschaos/litmusctl/pkg/utils"
-	"github.com/spf13/cobra"
 	"os"
 	"strings"
+
+	"github.com/litmuschaos/litmusctl/pkg/apis"
+	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
+	"github.com/litmuschaos/litmusctl/pkg/utils"
+	"github.com/spf13/cobra"
 )
 
 // experimentCmd represents the project command
@@ -118,4 +120,7 @@ func init() {
 
 	experimentCmd.Flags().String("project-id", "", "Set the project-id to create Chaos Experiment for the particular project. To see the projects, apply litmusctl get projects")
 	experimentCmd.Flags().String("experiment-id", "", "Set the environment-id to create Chaos Experiment for the particular Chaos Infrastructure. To see the Chaos Infrastructures, apply litmusctl get chaos-infra")
+
+	experimentCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+	experimentCmd.RegisterFlagCompletionFunc("experiment-id", completion.ExperimentIDCompletion)
 }

--- a/pkg/cmd/save/experiment.go
+++ b/pkg/cmd/save/experiment.go
@@ -17,10 +17,13 @@ package save
 
 import (
 	"fmt"
-	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
-	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
 	"os"
 	"strings"
+
+	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
+	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
+
 	//"time"
 
 	//"github.com/gorhill/cronexpr"
@@ -146,4 +149,8 @@ func init() {
 	experimentCmd.Flags().String("chaos-infra-id", "", "Set the chaos-infra-id to create Chaos Experiment for the particular Chaos Infrastructure. To see the Chaos Infrastructures, apply litmusctl get chaos-infra")
 	experimentCmd.Flags().StringP("file", "f", "", "The manifest file for the Chaos Experiment")
 	experimentCmd.Flags().StringP("description", "d", "", "The Description for the Chaos Experiment")
+
+	experimentCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+	experimentCmd.RegisterFlagCompletionFunc("chaos-infra-id", completion.ChaosInfraFlagCompletion)
+
 }

--- a/pkg/cmd/upgrade/agent.go
+++ b/pkg/cmd/upgrade/agent.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/litmuschaos/litmusctl/pkg/apis"
+	"github.com/litmuschaos/litmusctl/pkg/completion"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -66,4 +67,7 @@ func init() {
 	agentCmd.Flags().String("project-id", "", "Enter the project ID")
 	agentCmd.Flags().String("kubeconfig", "", "Enter the kubeconfig path(default: $HOME/.kube/config))")
 	agentCmd.Flags().String("chaos-delegate-id", "", "Enter the Chaos Delegate ID")
+
+	agentCmd.RegisterFlagCompletionFunc("project-id", completion.ProjectIDFlagCompletion)
+
 }

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -1,0 +1,143 @@
+package completion
+
+import (
+	"strings"
+
+	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
+	"github.com/litmuschaos/litmusctl/pkg/apis"
+	"github.com/litmuschaos/litmusctl/pkg/apis/experiment"
+	"github.com/litmuschaos/litmusctl/pkg/apis/infrastructure"
+	"github.com/litmuschaos/litmusctl/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+func ProjectIDFlagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	credentials, err := utils.GetCredentials(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	projects, err := apis.ListProject(credentials)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	completions := make([]string, 0)
+	descriptions := make(map[string]string)
+
+	for _, project := range projects.Data {
+		if strings.HasPrefix(project.ID, toComplete) {
+			completions = append(completions, project.ID)
+			descriptions[project.ID] = project.Name
+		}
+	}
+
+	var result []string
+	for _, c := range completions {
+		result = append(result, c+"\t"+descriptions[c])
+	}
+
+	return result, cobra.ShellCompDirectiveNoFileComp
+}
+
+func ExperimentIDCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	credentials, err := utils.GetCredentials(cmd)
+	if err != nil {
+		// Handle the error here if needed
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	pid := cmd.Flag("project-id").Value.String()
+	if pid == "" {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var listExperimentRequest model.ListExperimentRequest
+	listExperimentRequest.Filter = &model.ExperimentFilterInput{}
+
+	experiments, err := experiment.GetExperimentList(pid, listExperimentRequest, credentials)
+	if err != nil {
+		// Handle the error here if needed
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	completions := make([]string, 0)
+	descriptions := make(map[string]string)
+
+	for _, experiment := range experiments.Data.ListExperimentDetails.Experiments {
+		if strings.HasPrefix(experiment.ExperimentID, toComplete) {
+			completions = append(completions, experiment.ExperimentID)
+			descriptions[experiment.ExperimentID] = experiment.Infra.Name + "/" + experiment.Name
+		}
+	}
+
+	var result []string
+	for _, c := range completions {
+		result = append(result, c+"\t"+descriptions[c])
+	}
+
+	return result, cobra.ShellCompDirectiveNoFileComp
+}
+
+func ChaosInfraFlagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	credentials, err := utils.GetCredentials(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	pid := cmd.Flag("project-id").Value.String()
+	if pid == "" {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var listExperimentRequest model.ListExperimentRequest
+	listExperimentRequest.Filter = &model.ExperimentFilterInput{}
+
+	infras, err := infrastructure.GetInfraList(credentials, pid, model.ListInfraRequest{})
+	if err != nil {
+		if strings.Contains(err.Error(), "permission_denied") {
+			return nil, cobra.ShellCompDirectiveError
+
+		} else {
+			return nil, cobra.ShellCompDirectiveError
+
+		}
+	}
+
+	completions := make([]string, 0)
+	descriptions := make(map[string]string)
+
+	for _, infra := range infras.Data.ListInfraDetails.Infras {
+		if strings.HasPrefix(infra.InfraID, toComplete) {
+			completions = append(completions, infra.InfraID)
+			descriptions[infra.InfraID] = infra.Name
+		}
+	}
+
+	var result []string
+	for _, c := range completions {
+		result = append(result, c+"\t"+descriptions[c])
+	}
+	return result, cobra.ShellCompDirectiveNoFileComp
+}
+
+func OutputFlagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
+}
+
+func InstallModeTypeFlagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"cluster", "namespace"}, cobra.ShellCompDirectiveNoFileComp
+}
+
+func ChaosInfraTypeFlagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"external", "internal"}, cobra.ShellCompDirectiveNoFileComp
+}
+
+func PlatformNameFlagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"AWS", "GKE", "Openshift", "Rancher", "Others"}, cobra.ShellCompDirectiveNoFileComp
+}


### PR DESCRIPTION
Add completion for parameters values.

--project-id, Fetch projects from instance.
--experiment-id, Fetch experiments from instance. (project-id flag need to be set)

![image](https://github.com/litmuschaos/litmusctl/assets/87191932/e1a3e59d-268b-4022-a179-ebdd5ccef6af)

--chaos-infra-id, Fetch infrasID from instance. (project-id flag need to be set)
--chaos-infra, Fetch infrasID from instance. (project-id flag need to be set)

![image](https://github.com/litmuschaos/litmusctl/assets/87191932/dc541bdc-9d2c-4e58-9a54-0575dfee6f77)

--output, values are "json", "yaml"

![image](https://github.com/litmuschaos/litmusctl/assets/87191932/e169a584-79ec-44f6-a720-ffacec738237)

--installation-mode, values are "cluster", "namespace"
--type, values are "cluster", "namespace"
--platform-name, values are "AWS", "GKE", "Openshift", "Rancher", "Others"
--chaos-infra-type, values are "external", "internal"

![image](https://github.com/litmuschaos/litmusctl/assets/87191932/0b48cdee-9d68-44d4-89cc-142a4d11c72f)

I added the completion for those parameters on all commands.

Add completion for args.

litmus describe|save chaos-experiment
![image](https://github.com/litmuschaos/litmusctl/assets/87191932/78e9ba7f-c2a5-4fbe-bd34-3866557c69ec)


I tested the completion on bash only.

For bash:

```
source <(litmusctl completion bash)
```

For others, check the cobra completion doc:

```
litmusctl completion --help
```