### PR TITLE
added changes to add server endpoint

### DIFF
--- a/pkg/apis/environment/environment.go
+++ b/pkg/apis/environment/environment.go
@@ -3,12 +3,13 @@ package environment
 import (
 	"encoding/json"
 	"errors"
+	"io/ioutil"
+	"net/http"
+
 	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
 	"github.com/litmuschaos/litmusctl/pkg/apis"
 	"github.com/litmuschaos/litmusctl/pkg/types"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
-	"io/ioutil"
-	"net/http"
 )
 
 // CreateEnvironment connects the  Infra with the given details
@@ -19,7 +20,7 @@ func CreateEnvironment(pid string, request models.CreateEnvironmentRequest, cred
 	gqlReq.Variables.Request = request
 
 	query, err := json.Marshal(gqlReq)
-	resp, err := apis.SendRequest(apis.SendRequestParams{Endpoint: cred.Endpoint + utils.GQLAPIPath, Token: cred.Token}, query, string(types.Post))
+	resp, err := apis.SendRequest(apis.SendRequestParams{Endpoint: cred.ServerEndpoint + utils.GQLAPIPath, Token: cred.Token}, query, string(types.Post))
 	if err != nil {
 		return CreateEnvironmentResponse{}, errors.New("Error in Creating Chaos Infrastructure: " + err.Error())
 	}
@@ -60,7 +61,7 @@ func GetEnvironmentList(pid string, cred types.Credentials) (ListEnvironmentData
 
 	resp, err := apis.SendRequest(
 		apis.SendRequestParams{
-			Endpoint: cred.Endpoint + utils.GQLAPIPath,
+			Endpoint: cred.ServerEndpoint + utils.GQLAPIPath,
 			Token:    cred.Token,
 		},
 		query,

--- a/pkg/apis/experiment/experiment.go
+++ b/pkg/apis/experiment/experiment.go
@@ -18,12 +18,13 @@ package experiment
 import (
 	"encoding/json"
 	"errors"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
 	"github.com/litmuschaos/litmusctl/pkg/apis"
 	"github.com/litmuschaos/litmusctl/pkg/types"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
-	"io/ioutil"
-	"net/http"
 )
 
 // CreateExperiment sends GraphQL API request for creating a Experiment
@@ -43,7 +44,7 @@ func CreateExperiment(pid string, requestData model.SaveChaosExperimentRequest, 
 
 	resp, err := apis.SendRequest(
 		apis.SendRequestParams{
-			Endpoint: cred.Endpoint + utils.GQLAPIPath,
+			Endpoint: cred.ServerEndpoint + utils.GQLAPIPath,
 			Token:    cred.Token,
 		},
 		query,
@@ -80,7 +81,7 @@ func CreateExperiment(pid string, requestData model.SaveChaosExperimentRequest, 
 
 	// Query to Run the Chaos Experiment
 	runQuery := `{"query":"mutation{ \n runChaosExperiment(experimentID:  \"` + requestData.ID + `\", projectID:  \"` + pid + `\"){\n notifyID \n}}"}`
-	resp, err = apis.SendRequest(apis.SendRequestParams{Endpoint: cred.Endpoint + utils.GQLAPIPath, Token: cred.Token}, []byte(runQuery), string(types.Post))
+	resp, err = apis.SendRequest(apis.SendRequestParams{Endpoint: cred.ServerEndpoint + utils.GQLAPIPath, Token: cred.Token}, []byte(runQuery), string(types.Post))
 
 	if err != nil {
 		return RunExperimentResponse{}, errors.New("Error in Running Chaos Experiment: " + err.Error())
@@ -124,7 +125,7 @@ func SaveExperiment(pid string, requestData model.SaveChaosExperimentRequest, cr
 
 	resp, err := apis.SendRequest(
 		apis.SendRequestParams{
-			Endpoint: cred.Endpoint + utils.GQLAPIPath,
+			Endpoint: cred.ServerEndpoint + utils.GQLAPIPath,
 			Token:    cred.Token,
 		},
 		query,
@@ -166,7 +167,7 @@ func RunExperiment(pid string, eid string, cred types.Credentials) (RunExperimen
 	var err error
 	runQuery := `{"query":"mutation{ \n runChaosExperiment(experimentID:  \"` + eid + `\", projectID:  \"` + pid + `\"){\n notifyID \n}}"}`
 
-	resp, err := apis.SendRequest(apis.SendRequestParams{Endpoint: cred.Endpoint + utils.GQLAPIPath, Token: cred.Token}, []byte(runQuery), string(types.Post))
+	resp, err := apis.SendRequest(apis.SendRequestParams{Endpoint: cred.ServerEndpoint + utils.GQLAPIPath, Token: cred.Token}, []byte(runQuery), string(types.Post))
 
 	if err != nil {
 		return RunExperimentResponse{}, errors.New("Error in Running Chaos Experiment: " + err.Error())
@@ -211,7 +212,7 @@ func GetExperimentList(pid string, in model.ListExperimentRequest, cred types.Cr
 
 	resp, err := apis.SendRequest(
 		apis.SendRequestParams{
-			Endpoint: cred.Endpoint + utils.GQLAPIPath,
+			Endpoint: cred.ServerEndpoint + utils.GQLAPIPath,
 			Token:    cred.Token,
 		},
 		query,
@@ -261,7 +262,7 @@ func GetExperimentRunsList(pid string, in model.ListExperimentRunRequest, cred t
 
 	resp, err := apis.SendRequest(
 		apis.SendRequestParams{
-			Endpoint: cred.Endpoint + utils.GQLAPIPath,
+			Endpoint: cred.ServerEndpoint + utils.GQLAPIPath,
 			Token:    cred.Token,
 		},
 		query,
@@ -313,7 +314,7 @@ func DeleteChaosExperiment(projectID string, experimentID *string, cred types.Cr
 
 	resp, err := apis.SendRequest(
 		apis.SendRequestParams{
-			Endpoint: cred.Endpoint + utils.GQLAPIPath,
+			Endpoint: cred.ServerEndpoint + utils.GQLAPIPath,
 			Token:    cred.Token,
 		},
 		query,

--- a/pkg/apis/infrastructure/infra.go
+++ b/pkg/apis/infrastructure/infra.go
@@ -18,10 +18,12 @@ package infrastructure
 import (
 	"encoding/json"
 	"errors"
-	"github.com/litmuschaos/litmusctl/pkg/apis"
-	"github.com/litmuschaos/litmusctl/pkg/types"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/litmuschaos/litmusctl/pkg/apis"
+	"github.com/litmuschaos/litmusctl/pkg/types"
 
 	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
@@ -38,7 +40,7 @@ func GetInfraList(c types.Credentials, pid string, request models.ListInfraReque
 	if err != nil {
 		return InfraData{}, err
 	}
-	resp, err := apis.SendRequest(apis.SendRequestParams{Endpoint: c.Endpoint + utils.GQLAPIPath, Token: c.Token}, query, string(types.Post))
+	resp, err := apis.SendRequest(apis.SendRequestParams{Endpoint: c.ServerEndpoint + utils.GQLAPIPath, Token: c.Token}, query, string(types.Post))
 	if err != nil {
 		return InfraData{}, err
 	}
@@ -46,6 +48,7 @@ func GetInfraList(c types.Credentials, pid string, request models.ListInfraReque
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
+
 		return InfraData{}, err
 	}
 
@@ -62,7 +65,7 @@ func GetInfraList(c types.Credentials, pid string, request models.ListInfraReque
 
 		return Infra, nil
 	} else {
-		return InfraData{}, err
+		return InfraData{}, fmt.Errorf("error getting detais from server")
 	}
 }
 
@@ -94,7 +97,7 @@ func ConnectInfra(infra types.Infra, cred types.Credentials) (InfraConnectionDat
 	}
 
 	query, err := json.Marshal(gqlReq)
-	resp, err := apis.SendRequest(apis.SendRequestParams{Endpoint: cred.Endpoint + utils.GQLAPIPath, Token: cred.Token}, query, string(types.Post))
+	resp, err := apis.SendRequest(apis.SendRequestParams{Endpoint: cred.ServerEndpoint + utils.GQLAPIPath, Token: cred.Token}, query, string(types.Post))
 	if err != nil {
 		return InfraConnectionData{}, errors.New("Error in registering Chaos Infrastructure: " + err.Error())
 	}
@@ -160,7 +163,7 @@ func DisconnectInfra(projectID string, infraID string, cred types.Credentials) (
 
 	resp, err := apis.SendRequest(
 		apis.SendRequestParams{
-			Endpoint: cred.Endpoint + utils.GQLAPIPath,
+			Endpoint: cred.ServerEndpoint + utils.GQLAPIPath,
 			Token:    cred.Token,
 		},
 		query,

--- a/pkg/apis/project.go
+++ b/pkg/apis/project.go
@@ -83,7 +83,7 @@ func CreateProjectRequest(projectName string, cred types.Credentials) (createPro
 
 type listProjectResponse struct {
 	Data []struct {
-		ID        string `json:"ID"`
+		ID        string `json:"projectID"`
 		Name      string `json:"Name"`
 		CreatedAt int64  `json:"CreatedAt"`
 	} `json:"data"`
@@ -139,14 +139,14 @@ type Data struct {
 
 type Member struct {
 	Role     string `json:"Role"`
-	UserID   string `json:"UserID"`
-	UserName string `json:"UserName"`
+	UserID   string `json:"userID"`
+	UserName string `json:"username"`
 }
 
 type Project struct {
-	ID        string   `json:"ID"`
+	ID        string   `json:"projectID"`
 	Name      string   `json:"Name"`
-	CreatedAt string   `json:"created_at"`
+	CreatedAt int64    `json:"createdAt"`
 	Members   []Member `json:"Members"`
 }
 

--- a/pkg/cmd/create/environment.go
+++ b/pkg/cmd/create/environment.go
@@ -17,13 +17,14 @@ package create
 
 import (
 	"fmt"
+	"os"
+
 	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
 	"github.com/litmuschaos/litmusctl/pkg/apis"
 	"github.com/litmuschaos/litmusctl/pkg/apis/environment"
 	"github.com/litmuschaos/litmusctl/pkg/infra_ops"
 	"github.com/litmuschaos/litmusctl/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // environmentCmd represents the Chaos infra command
@@ -77,7 +78,9 @@ var environmentCmd = &cobra.Command{
 		newEnvironment.Description = &description
 
 		envType, err := cmd.Flags().GetString("type")
-		utils.PrintError(err)
+		if err != nil {
+			utils.PrintError(err)
+		}
 
 		// Handle blank input for project ID
 		if envType == "" {
@@ -92,7 +95,9 @@ var environmentCmd = &cobra.Command{
 		newEnvironment.Type = models.EnvironmentType(envType)
 
 		envs, err := environment.GetEnvironmentList(pid, credentials)
-		utils.PrintError(err)
+		if err != nil {
+			utils.PrintError(err)
+		}
 
 		// Generate EnvironmentID from Environment Name
 		envID := utils.GenerateNameID(newEnvironment.Name)
@@ -115,7 +120,9 @@ var environmentCmd = &cobra.Command{
 
 		// Perform authorization
 		userDetails, err := apis.GetProjectDetails(credentials)
-		utils.PrintError(err)
+		if err != nil {
+			utils.PrintError(err)
+		}
 		var editAccess = false
 		var project apis.Project
 		for _, p := range userDetails.Data.Projects {

--- a/pkg/cmd/get/infra.go
+++ b/pkg/cmd/get/infra.go
@@ -17,11 +17,12 @@ package get
 
 import (
 	"fmt"
-	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
-	"github.com/litmuschaos/litmusctl/pkg/apis/infrastructure"
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	models "github.com/litmuschaos/litmus/chaoscenter/graphql/server/graph/model"
+	"github.com/litmuschaos/litmusctl/pkg/apis/infrastructure"
 
 	"github.com/litmuschaos/litmusctl/pkg/utils"
 	"github.com/spf13/cobra"
@@ -52,7 +53,7 @@ var InfraCmd = &cobra.Command{
 		infras, err := infrastructure.GetInfraList(credentials, projectID, models.ListInfraRequest{})
 		if err != nil {
 			if strings.Contains(err.Error(), "permission_denied") {
-				utils.Red.Println("❌ The specified Project ID doesn't exist.")
+				utils.Red.Println("❌ you don't have enough permissions to access this project")
 				os.Exit(1)
 			} else {
 				utils.PrintError(err)

--- a/pkg/config/ops.go
+++ b/pkg/config/ops.go
@@ -106,6 +106,7 @@ func UpdateLitmusCtlConfig(litmusconfig types.UpdateLitmusCtlConfig, filename st
 	for i, act := range obj.Accounts {
 		if act.Endpoint == litmusconfig.Account.Endpoint {
 			var innerflag = false
+			obj.Accounts[i].ServerEndpoint = litmusconfig.ServerEndpoint
 			for j, user := range act.Users {
 				if user.Username == litmusconfig.Account.Users[0].Username {
 					obj.Accounts[i].Users[j].Username = litmusconfig.Account.Users[0].Username

--- a/pkg/types/api_types.go
+++ b/pkg/types/api_types.go
@@ -29,13 +29,15 @@ type AuthResponse struct {
 }
 
 type AuthInput struct {
-	Endpoint string
-	Username string
-	Password string
+	Endpoint       string
+	Username       string
+	Password       string
+	ServerEndpoint string
 }
 
 type Credentials struct {
-	Username string
-	Token    string
-	Endpoint string
+	Username       string
+	Token          string
+	Endpoint       string
+	ServerEndpoint string
 }

--- a/pkg/types/config_types.go
+++ b/pkg/types/config_types.go
@@ -22,8 +22,9 @@ type User struct {
 }
 
 type Account struct {
-	Users    []User `yaml:"users" json:"users"`
-	Endpoint string `yaml:"endpoint" json:"endpoint"`
+	Users          []User `yaml:"users" json:"users"`
+	Endpoint       string `yaml:"endpoint" json:"endpoint"`
+	ServerEndpoint string `yaml:"serverEndpoint" json:"serverEndpoint"`
 }
 
 type LitmuCtlConfig struct {
@@ -43,4 +44,5 @@ type UpdateLitmusCtlConfig struct {
 	CurrentAccount string  `yaml:"current-account" json:"current-account"`
 	CurrentUser    string  `yaml:"current-user" json:"current-user"`
 	Account        Account `yaml:"account" json:"account"`
+	ServerEndpoint string  `yaml:"serverEndpoint" json:"serverEndpoint"`
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -83,8 +83,10 @@ func GetCredentials(cmd *cobra.Command) (types.Credentials, error) {
 	}
 
 	var token string
+	var serverEndpoint string
 	for _, account := range obj.Accounts {
 		if account.Endpoint == obj.CurrentAccount {
+			serverEndpoint = account.ServerEndpoint
 			for _, user := range account.Users {
 				if user.Username == obj.CurrentUser {
 					token = user.Token
@@ -94,9 +96,10 @@ func GetCredentials(cmd *cobra.Command) (types.Credentials, error) {
 	}
 
 	return types.Credentials{
-		Username: obj.CurrentUser,
-		Token:    token,
-		Endpoint: obj.CurrentAccount,
+		Username:       obj.CurrentUser,
+		Token:          token,
+		Endpoint:       obj.CurrentAccount,
+		ServerEndpoint: serverEndpoint,
 	}, nil
 }
 


### PR DESCRIPTION
This PR will add serverEndpoint in the litmusconfig file which can be configured as per the development setup. serverEndpoint is the endpoint where graphql server is running.

``` accounts:
- users:
  - expires_in: "1697525696"
    token: <jwt_token>
    username: admin
  endpoint: http://localhost:3000
  serverEndpoint: http://localhost:8080
apiVersion: v1
current-account: http://localhost:3000
current-user: admin
kind: Config 
```