### PR TITLE
Fix : Index out of bound error for get projects command

### DIFF
--- a/pkg/cmd/get/projects.go
+++ b/pkg/cmd/get/projects.go
@@ -60,6 +60,11 @@ var projectsCmd = &cobra.Command{
 					end = totalProjects
 
 				}
+				// check if there are no more projects to display
+				if start >= totalProjects {
+					utils.Red.Println("No more projects to display")
+					break
+				}
 
 				// displaying the projects for the current page
 				writer := tabwriter.NewWriter(os.Stdout, 8, 8, 8, '\t', tabwriter.AlignRight)


### PR DESCRIPTION
closes #183

Added a little customized error message if the start index is greater than the total projects. This shall give a more appropriate error message rather than throwing a index out of bound error.