### PR TITLE
Added a new command to change version

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/litmuschaos/litmusctl/pkg/cmd/run"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/save"
+	"github.com/litmuschaos/litmusctl/pkg/cmd/update"
 
 	"github.com/litmuschaos/litmusctl/pkg/cmd/connect"
 	"github.com/litmuschaos/litmusctl/pkg/cmd/delete"
@@ -77,6 +78,7 @@ func init() {
 	rootCmd.AddCommand(save.SaveCmd)
 	rootCmd.AddCommand(run.RunCmd)
 	rootCmd.AddCommand(list.ListCmd)
+	rootCmd.AddCommand(update.UpdateCmd)
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -1,0 +1,94 @@
+package update
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/litmuschaos/litmusctl/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var UpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Changes the version of litmusctl",
+	Args:  cobra.ExactArgs(1),
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		updateVersion := args[0]
+		var homeDir = "/usr/local/bin/"
+
+		var assetURL string = "https://litmusctl-production-bucket.s3.amazonaws.com/"
+		var binaryName string = "litmusctl"
+		switch runtime.GOOS {
+		case "windows":
+			if runtime.GOARCH == "386" {
+				binaryName += "-windows-386-" + updateVersion + ".tar.gz"
+				assetURL += binaryName
+			} else if runtime.GOARCH == "amd64" {
+				binaryName += "-windows-amd64-" + updateVersion + ".tar.gz"
+				assetURL += binaryName
+			} else {
+				binaryName += "-windows-arm64-" + updateVersion + ".tar.gz"
+				assetURL += binaryName
+			}
+		case "linux":
+			if runtime.GOARCH == "arm64" {
+				binaryName += "-linux-arm64-" + updateVersion + ".tar.gz"
+				assetURL += binaryName
+			} else if runtime.GOARCH == "amd64" {
+				binaryName += "-linux-amd64-" + updateVersion + ".tar.gz"
+				assetURL += binaryName
+			} else if runtime.GOARCH == "arm" {
+				binaryName += "-linux-arm-" + updateVersion + ".tar.gz"
+				assetURL += binaryName
+			} else {
+				binaryName += "-linux-386-" + updateVersion + ".tar.gz"
+				assetURL += binaryName
+			}
+		case "darwin":
+			if runtime.GOARCH == "amd64" {
+				binaryName += "-darwin-amd64-" + updateVersion + ".tar.gz"
+				assetURL += binaryName
+			}
+		}
+
+		utils.White.Print("Downloading:\n")
+
+		resp2, err := http.Get(assetURL)
+		if err != nil {
+			utils.PrintError(err)
+		}
+
+		tempFile, err := os.CreateTemp("", binaryName)
+		if err != nil {
+			utils.PrintError(err)
+			return
+		}
+		defer os.Remove(tempFile.Name())
+
+		_, err = io.Copy(tempFile, resp2.Body)
+		if err != nil {
+			utils.PrintError(err)
+			return
+		}
+		utils.White_B.Print("OK\n")
+
+		tempFile.Close()
+
+		tarCmd := exec.Command("tar", "xzf", tempFile.Name(), "-C", homeDir)
+		tarCmd.Stdout = os.Stdout
+		tarCmd.Stderr = os.Stderr
+
+		utils.White_B.Print("Extracting binary...\n")
+		err = tarCmd.Run()
+		if err != nil {
+			utils.PrintError(err)
+			return
+		}
+
+		utils.White_B.Print("Binary extracted successfully\n")
+	},
+}

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 
 	"github.com/litmuschaos/litmusctl/pkg/utils"
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/litmuschaos/litmusctl/pkg/utils"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +19,10 @@ var UpdateCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		updateVersion := args[0]
-		var homeDir = "/usr/local/bin/"
+		homeDir, err := homedir.Dir()
+		if err != nil {
+			utils.PrintError(err)
+		}
 
 		var assetURL string = "https://litmusctl-production-bucket.s3.amazonaws.com/"
 		var binaryName string = "litmusctl"


### PR DESCRIPTION
Added upgrade command to change version of the litmusctl binary, works like `sudo litmusctl update 1.1.0`, tested on linux arm64 architecture. It works for every version that exists, meaning not only it can upgrade but downgrade as well, but the command upgrade is already taken hence I chose update.
Fixes [#3307](https://github.com/litmuschaos/litmus/issues/3307)