### PR TITLE
scripts: added makefile target for linting the code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,9 @@ unused-package-check:
 	if [ -n "$${tidy}" ]; then \
 		echo "go mod tidy checking failed!"; echo "$${tidy}"; echo; \
 	fi
+.PHONY: format_and_lint
+format_and_lint:
+	@echo "------------------"
+	@echo "--> Formatting and linting the code"
+	@echo "------------------"
+	@bash scripts/lint-check.sh

--- a/scripts/lint-check.sh
+++ b/scripts/lint-check.sh
@@ -1,0 +1,2 @@
+find . -name '*.go' -type f -exec gofmt -s -w {} \;
+golangci-lint run --enable goimports --enable gofmt --timeout 10m


### PR DESCRIPTION
Part of #196, this is primarily for contributors to ensure their code doesn't have any linting issues and can conveniently check by running `make lint-check`, it will also ensure [this issue](https://github.com/litmuschaos/litmusctl/issues/190) doesn't repeat in the future.

We may also add this to documentation for contributors to run this before creating a PR.