### PR TITLE
Add Support for getExperimentRun and podLog GraphQL Queries

### DIFF
--- a/pkg/apis/experiment/query.go
+++ b/pkg/apis/experiment/query.go
@@ -44,11 +44,41 @@ const (
                         }
                       }
                     }`
+
+	ExperimentRunsQuery = `query getExperimentRun($projectID: ID!, $experimentRunID: ID, $notifyID: ID) {
+                        getExperimentRun(
+                            projectID: $projectID
+                            experimentRunID: $experimentRunID
+                            notifyID: $notifyID
+                          ) 
+                          {
+                          experimentRunID
+                          experimentID
+                          experimentName
+                          infra {
+                          name
+                          infraID
+                          }
+                          updatedAt
+                          updatedBy{
+                              username
+                          }
+                          phase
+                          resiliencyScore
+                          executionData
+                        }
+                      }`
 	DeleteExperimentQuery = `mutation deleteChaosExperiment($projectID: ID!, $experimentID: String!, $experimentRunID: String) {
                       deleteChaosExperiment(
                         projectID: $projectID
                         experimentID: $experimentID
                         experimentRunID: $experimentRunID
                       )
+                    }`
+	GetPodLogsQuery = `subscription podLog($request: PodLogRequest!) {
+                      getPodLog(request: $request) {
+                        log
+                        __typename
+                      }
                     }`
 )

--- a/pkg/apis/experiment/types.go
+++ b/pkg/apis/experiment/types.go
@@ -54,6 +54,18 @@ type GetChaosExperimentsGraphQLRequest struct {
 	} `json:"variables"`
 }
 
+type ExperimentRunData struct {
+	Errors []struct {
+		Message string   `json:"message"`
+		Path    []string `json:"path"`
+	} `json:"errors"`
+	Data ExperimentRun `json:"data"`
+}
+
+type ExperimentRun struct {
+	ExperimentRunDetails model.ExperimentRun `json:"getExperimentRun"`
+}
+
 type ExperimentRunListData struct {
 	Errors []struct {
 		Message string   `json:"message"`
@@ -66,11 +78,19 @@ type ExperimentRunsList struct {
 	ListExperimentRunDetails model.ListExperimentRunResponse `json:"listExperimentRun"`
 }
 
-type GetChaosExperimentRunGraphQLRequest struct {
+type GetChaosExperimentRunsGraphQLRequest struct {
 	Query     string `json:"query"`
 	Variables struct {
 		ProjectID                    string                         `json:"projectID"`
 		GetChaosExperimentRunRequest model.ListExperimentRunRequest `json:"request"`
+	} `json:"variables"`
+}
+
+type GetChaosExperimentRunGraphQLRequest struct {
+	Query     string `json:"query"`
+	Variables struct {
+		ProjectID string `json:"projectID"`
+		NotifyID  string `json:"notifyID"`
 	} `json:"variables"`
 }
 
@@ -92,5 +112,40 @@ type DeleteChaosExperimentGraphQLRequest struct {
 		ProjectID       string  `json:"projectID"`
 		ExperimentID    *string `json:"experimentID"`
 		ExperimentRunID *string `json:"experimentRunID"`
+	} `json:"variables"`
+}
+
+type PodLogResponse struct {
+	Log      string `json:"log"`
+	Typename string `json:"__typename"`
+}
+
+type PodLogDetails struct {
+	GetPodLog PodLogResponse `json:"getPodLog"`
+}
+
+type PodLogData struct {
+	Errors []struct {
+		Message string   `json:"message"`
+		Path    []string `json:"path"`
+	} `json:"errors"`
+	Data PodLogDetails `json:"data"`
+}
+
+// Define the PodLogRequest structure
+type PodLogRequest struct {
+	InfraID         string `json:"infraID"`
+	ExperimentRunID string `json:"experimentRunID"`
+	PodName         string `json:"podName"`
+	PodNamespace    string `json:"podNamespace"`
+	PodType         string `json:"podType"`
+	RunnerPod       string `json:"runnerPod"`
+	ChaosNamespace  string `json:"chaosNamespace"`
+}
+
+type GetPodLogsGraphQLRequest struct {
+	Query     string `json:"query"`
+	Variables struct {
+		Request PodLogRequest `json:"request"`
 	} `json:"variables"`
 }


### PR DESCRIPTION
This PR introduces support for executing the getExperimentRun and podLog GraphQL queries directly from the codebase. These additions will enable fetching logs after running an experiment, providing enhanced visibility and facilitating troubleshooting. These queries also offer flexibility for potential future use cases where log retrieval or experiment run details are needed.