### PR TITLE
fix: error on fetching projects when there are no projects

### DIFF
--- a/pkg/apis/project.go
+++ b/pkg/apis/project.go
@@ -82,7 +82,8 @@ func CreateProjectRequest(projectName string, cred types.Credentials) (CreatePro
 }
 
 type listProjectResponse struct {
-	Data struct {
+	Message string `json:"message"`
+	Data    struct {
 		Projects []struct {
 			ID        string `json:"projectID"` // Adjusted field name
 			Name      string `json:"name"`


### PR DESCRIPTION
This PR fixes the error on fetching projects when there are no projects created by user.

Fixes #264 


This PR is dependent on this [PR](https://github.com/litmuschaos/litmus/pull/5011) in the main repo.