### PR TITLE
Add stream-logs flag ito fetch and stream logs from the Pod is needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# auto-build: {"image_name": "chaos-as-service/litmusctl-sumo, "tags": ["latest"], "platform": "linux/amd64,linux/arm64"}
+
+FROM golang:1.23.4 AS builder
+WORKDIR /litmusctl
+COPY . .
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -o litmusctl main.go
+RUN chmod +x litmusctl
+RUN cp litmusctl /usr/local/bin
+
+FROM alpine:latest
+WORKDIR /litmusctl
+COPY --from=builder /litmusctl/ ./
+RUN cp ./litmusctl /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# auto-build: {"image_name": "chaos-as-service/litmusctl-sumo, "tags": ["latest"], "platform": "linux/amd64,linux/arm64"}
+# auto-build: {"image_name": "chaos-as-service/litmusctl-sumo", "tags": ["latest"], "platform": "linux/amd64,linux/arm64"}
 
 FROM golang:1.23.4 AS builder
 WORKDIR /litmusctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# auto-build: {"image_name": "chaos-as-service/litmusctl-sumo", "tags": ["latest"], "platform": "linux/amd64,linux/arm64"}
+# auto-build: {"image_name": "chaos-as-service/litmusctl-sumo", "tags": ["latest"], "platform": "linux/amd64,linux/arm64", "cron":"@weekly"}
 
 FROM golang:1.23.4 AS builder
 WORKDIR /litmusctl

--- a/pkg/apis/experiment/query.go
+++ b/pkg/apis/experiment/query.go
@@ -44,11 +44,41 @@ const (
                         }
                       }
                     }`
+
+	ExperimentRunsQuery = `query getExperimentRun($projectID: ID!, $experimentRunID: ID, $notifyID: ID) {
+                        getExperimentRun(
+                            projectID: $projectID
+                            experimentRunID: $experimentRunID
+                            notifyID: $notifyID
+                          ) 
+                          {
+                          experimentRunID
+                          experimentID
+                          experimentName
+                          infra {
+                          name
+                          infraID
+                          }
+                          updatedAt
+                          updatedBy{
+                              username
+                          }
+                          phase
+                          resiliencyScore
+                          executionData
+                        }
+                      }`
 	DeleteExperimentQuery = `mutation deleteChaosExperiment($projectID: ID!, $experimentID: String!, $experimentRunID: String) {
                       deleteChaosExperiment(
                         projectID: $projectID
                         experimentID: $experimentID
                         experimentRunID: $experimentRunID
                       )
+                    }`
+	GetPodLogsQuery = `subscription podLog($request: PodLogRequest!) {
+                      getPodLog(request: $request) {
+                        log
+                        __typename
+                      }
                     }`
 )

--- a/pkg/apis/experiment/query.go
+++ b/pkg/apis/experiment/query.go
@@ -29,18 +29,66 @@ const (
                       listExperimentRun(projectID: $projectID, request: $request) {
                         totalNoOfExperimentRuns
                         experimentRuns {
+                          projectID
                           experimentRunID
+                          experimentType
                           experimentID
-                          experimentName
-                          infra {
-                          name
+                          weightages {
+                              faultName
+                              weightage
                           }
                           updatedAt
-                          updatedBy{
-                              username
+                          createdAt
+                          infra {
+                              projectID
+                              infraID                              
+                              name
+                              description
+                              tags
+                              environmentID
+                              platformName
+                              isActive
+                              isInfraConfirmed
+                              isRemoved
+                              updatedAt
+                              createdAt
+                              noOfExperiments
+                              noOfExperimentRuns
+                              token
+                              infraNamespace
+                              serviceAccount
+                              infraScope
+                              infraNsExists
+                              infraSaExists
+                              lastExperimentTimestamp
+                              startTime
+                              version
+                              infraType
+                              updateStatus
                           }
+                          experimentName
                           phase
                           resiliencyScore
+                          faultsPassed
+                          faultsFailed
+                          faultsAwaited
+                          faultsStopped
+                          faultsNa
+                          totalFaults
+                          executionData
+                          isRemoved
+                          updatedBy{
+                              userID
+                              username
+                              email
+                          }
+                          createdBy{
+                              userID
+                              username
+                              email
+                          }
+                          notifyID
+                          runSequence
                         }
                       }
                     }`

--- a/pkg/apis/experiment/types.go
+++ b/pkg/apis/experiment/types.go
@@ -54,6 +54,18 @@ type GetChaosExperimentsGraphQLRequest struct {
 	} `json:"variables"`
 }
 
+type ExperimentRunData struct {
+	Errors []struct {
+		Message string   `json:"message"`
+		Path    []string `json:"path"`
+	} `json:"errors"`
+	Data ExperimentRun `json:"data"`
+}
+
+type ExperimentRun struct {
+	ExperimentRunDetails model.ExperimentRun `json:"getExperimentRun"`
+}
+
 type ExperimentRunListData struct {
 	Errors []struct {
 		Message string   `json:"message"`
@@ -66,11 +78,19 @@ type ExperimentRunsList struct {
 	ListExperimentRunDetails model.ListExperimentRunResponse `json:"listExperimentRun"`
 }
 
-type GetChaosExperimentRunGraphQLRequest struct {
+type GetChaosExperimentRunsGraphQLRequest struct {
 	Query     string `json:"query"`
 	Variables struct {
 		ProjectID                    string                         `json:"projectID"`
 		GetChaosExperimentRunRequest model.ListExperimentRunRequest `json:"request"`
+	} `json:"variables"`
+}
+
+type GetChaosExperimentRunGraphQLRequest struct {
+	Query     string `json:"query"`
+	Variables struct {
+		ProjectID string `json:"projectID"`
+		NotifyID  string `json:"notifyID"`
 	} `json:"variables"`
 }
 
@@ -92,5 +112,40 @@ type DeleteChaosExperimentGraphQLRequest struct {
 		ProjectID       string  `json:"projectID"`
 		ExperimentID    *string `json:"experimentID"`
 		ExperimentRunID *string `json:"experimentRunID"`
+	} `json:"variables"`
+}
+
+type PodLogResponse struct {
+	Log      string `json:"log"`
+	Typename string `json:"__typename"`
+}
+
+type PodLogDetails struct {
+	GetPodLog PodLogResponse `json:"getPodLog"`
+}
+
+type PodLogData struct {
+	Errors []struct {
+		Message string   `json:"message"`
+		Path    []string `json:"path"`
+	} `json:"errors"`
+	Data PodLogDetails `json:"data"`
+}
+
+// Define the PodLogRequest structure
+type PodLogRequest struct {
+	InfraID         string `json:"infraID"`
+	ExperimentRunID string `json:"experimentRunID"`
+	PodName         string `json:"podName"`
+	PodNamespace    string `json:"podNamespace"`
+	PodType         string `json:"podType"`
+	RunnerPod       string `json:"runnerPod"`
+	ChaosNamespace  string `json:"chaosNamespace"`
+}
+
+type GetPodLogsGraphQLRequest struct {
+	Query     string `json:"query"`
+	Variables struct {
+		Request PodLogRequest `json:"request"`
 	} `json:"variables"`
 }

--- a/pkg/cmd/run/experiment.go
+++ b/pkg/cmd/run/experiment.go
@@ -212,7 +212,7 @@ var experimentCmd = &cobra.Command{
 					// Save the node state
 					seenNodes[nodeName] = node.Phase
 					// Check and log runnerPod & experimentPod if available
-					if node.ChaosData != nil && node.Phase == "Running" {
+					if node.ChaosData != nil {
 						podNames := []string{
 							node.ChaosData.RunnerPod,
 							node.ChaosData.ExpPod,
@@ -251,7 +251,8 @@ var experimentCmd = &cobra.Command{
 				}
 
 				if exp.Data.ExperimentRunDetails.Phase != "Running" &&
-					exp.Data.ExperimentRunDetails.Phase != "Queued" {
+					exp.Data.ExperimentRunDetails.Phase != "Queued" &&
+					exp.Data.ExperimentRunDetails.Phase != "Pending" {
 					break
 				}
 				time.Sleep(time.Second * 1)

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -187,3 +187,13 @@ func FormatTimeStamp(timestampEpoch string) string {
 	formattedTime := time.Unix(timestampEpochInt, 0).UTC().Format("02 Jan 2006, 15:04:05 UTC")
 	return formattedTime
 }
+
+func Diff(old string, new string) string {
+	var diff = ""
+	if strings.HasPrefix(new, old) {
+		diff = strings.TrimSpace(new[len(old):])
+	} else {
+		diff = strings.TrimSpace(new)
+	}
+	return diff
+}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -25,7 +25,9 @@ import (
 	"math/big"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/litmuschaos/litmusctl/pkg/config"
@@ -39,6 +41,8 @@ var (
 	Red     = color.New(color.FgRed)
 	White_B = color.New(color.FgWhite, color.Bold)
 	White   = color.New(color.FgWhite)
+	Cyan    = color.New(color.FgCyan)
+	Green   = color.New(color.FgGreen)
 )
 
 func Scanner() string {
@@ -169,4 +173,17 @@ func GenerateNameID(in string) string {
 	nameID := strings.ToLower(noHyphens)
 
 	return nameID
+}
+
+// FormatTimeStamp converts an epoch timestamp string to a formatted date-time string in UTC
+func FormatTimeStamp(timestampEpoch string) string {
+	timestampEpochInt, err := strconv.ParseInt(timestampEpoch, 10, 64)
+	if err != nil {
+		Red.Printf("Error converting epoch string to int: %v", err)
+		return "Invalid timestamp"
+	}
+
+	// Format the timestamp in a readable format
+	formattedTime := time.Unix(timestampEpochInt, 0).UTC().Format("02 Jan 2006, 15:04:05 UTC")
+	return formattedTime
 }


### PR DESCRIPTION
**This PR introduces a new CLI flag:**
Flag: --stream-logs
Default: false
Purpose: When enabled, it will fetch and stream logs from the associated experiment Pod in real time.

This is useful for users who want to monitor experiment execution live from the CLI without switching to the dashboard or kubectl logs.